### PR TITLE
PP-15481 Make date range filters and entered dates more consistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@pact-foundation/pact-core": "^19.2.0",
         "@percy/cli": "^1.31.8",
         "@percy/cypress": "^3.1.7",
+        "@types/bootstrap-datepicker": "^1.10.1",
         "@types/chai": "^5.2.2",
         "@types/chai-as-promised": "^8.0.2",
         "@types/client-sessions": "^0.8.6",
@@ -6058,6 +6059,16 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bootstrap-datepicker": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@types/bootstrap-datepicker/-/bootstrap-datepicker-1.10.1.tgz",
+      "integrity": "sha512-5g8l9GmAUVG620NbqlVCOkno7e60C+enD/ZYhsueTN9rr6K5WqAAtRes6U1dI28Tm3/XRjaaCvd75EL365Bi1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*"
       }
     },
     "node_modules/@types/chai": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@pact-foundation/pact-core": "^19.2.0",
     "@percy/cli": "^1.31.8",
     "@percy/cypress": "^3.1.7",
+    "@types/bootstrap-datepicker": "^1.10.1",
     "@types/chai": "^5.2.2",
     "@types/chai-as-promised": "^8.0.2",
     "@types/client-sessions": "^0.8.6",

--- a/src/client-side/date-select.ts
+++ b/src/client-side/date-select.ts
@@ -61,7 +61,6 @@ function setDateFilter() {
   const toDate = (document.getElementById('toDate') as HTMLInputElement).value
 
   const period = dateRangeAsPeriod(fromDate, toDate, TRANSACTION_SEARCH_DATE_FORMAT)
-  console.log(period)
   ;(document.getElementById('dateFilter') as HTMLInputElement).value = period ?? 'custom-range'
 }
 
@@ -95,7 +94,6 @@ function bindDatePickerChangeListener() {
     $('.date-picker')
       .datepicker()
       .on('changeDate', (_) => {
-        console.log('date changed')
         setDateFilter()
       })
   }

--- a/src/client-side/date-select.ts
+++ b/src/client-side/date-select.ts
@@ -4,11 +4,22 @@ import {
   getPeriodUKDateTimeRange,
   dateRangeAsPeriod,
 } from '@utils/simplified-account/services/dashboard/datetime-utils'
-declare const $: JQueryStatic
+declare const $: JQueryStatic | undefined
 
 import { TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
+import awaitJQuery from '@utils/client-side/await-jquery'
 
 function register() {
+  setJsEnabled()
+  bindDateFilterChangeListener()
+  bindIncludeTimeCheckboxListener()
+
+  awaitJQuery(() => {
+    bindDatePickerChangeListener()
+  })
+}
+
+function bindDateFilterChangeListener() {
   document.getElementById('dateFilter')?.addEventListener('change', (event) => {
     if (!(event.target instanceof HTMLSelectElement)) {
       return
@@ -22,14 +33,9 @@ function register() {
     setFromDate(dates.start)
     setEndDate(dates.end)
   })
+}
 
-  $('.date-picker')
-    .datepicker()
-    .on('changeDate', (_) => {
-      console.log('date changed')
-      setDateFilter()
-    })
-
+function bindIncludeTimeCheckboxListener() {
   document.getElementById('include-time-checkbox')?.addEventListener('change', (event) => {
     if (!(event.target instanceof HTMLInputElement)) {
       return
@@ -41,11 +47,16 @@ function register() {
       hideTimePicker()
     }
   })
-  ;(document.getElementById('js-enabled') as HTMLInputElement).value = 'true'
+}
+
+function setJsEnabled() {
+  const jsEnabledHiddenInput = document.getElementById('js-enabled')
+  if (jsEnabledHiddenInput instanceof HTMLInputElement) {
+    jsEnabledHiddenInput.value = 'true'
+  }
 }
 
 function setDateFilter() {
-  console.log('changed')
   const fromDate = (document.getElementById('fromDate') as HTMLInputElement).value
   const toDate = (document.getElementById('toDate') as HTMLInputElement).value
 
@@ -76,6 +87,17 @@ function setFromDate(date: DateTime | undefined) {
 function setEndDate(date: DateTime | undefined) {
   if (date) {
     ;(document.getElementById('toDate') as HTMLInputElement).value = date.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
+  }
+}
+
+function bindDatePickerChangeListener() {
+  if (Object.hasOwn(window, '$') && $) {
+    $('.date-picker')
+      .datepicker()
+      .on('changeDate', (_) => {
+        console.log('date changed')
+        setDateFilter()
+      })
   }
 }
 

--- a/src/client-side/date-select.ts
+++ b/src/client-side/date-select.ts
@@ -1,5 +1,12 @@
 import { DateTime } from 'luxon'
-import { Period, getPeriodUKDateTimeRange } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import {
+  Period,
+  getPeriodUKDateTimeRange,
+  dateRangeAsPeriod,
+} from '@utils/simplified-account/services/dashboard/datetime-utils'
+declare const $: JQueryStatic
+
+import { TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
 
 function register() {
   document.getElementById('dateFilter')?.addEventListener('change', (event) => {
@@ -16,6 +23,13 @@ function register() {
     setEndDate(dates.end)
   })
 
+  $('.date-picker')
+    .datepicker()
+    .on('changeDate', (_) => {
+      console.log('date changed')
+      setDateFilter()
+    })
+
   document.getElementById('include-time-checkbox')?.addEventListener('change', (event) => {
     if (!(event.target instanceof HTMLInputElement)) {
       return
@@ -27,6 +41,17 @@ function register() {
       hideTimePicker()
     }
   })
+  ;(document.getElementById('js-enabled') as HTMLInputElement).value = 'true'
+}
+
+function setDateFilter() {
+  console.log('changed')
+  const fromDate = (document.getElementById('fromDate') as HTMLInputElement).value
+  const toDate = (document.getElementById('toDate') as HTMLInputElement).value
+
+  const period = dateRangeAsPeriod(fromDate, toDate, TRANSACTION_SEARCH_DATE_FORMAT)
+  console.log(period)
+  ;(document.getElementById('dateFilter') as HTMLInputElement).value = period ?? 'custom-range'
 }
 
 function showTimePicker() {
@@ -44,13 +69,13 @@ function clearDates() {
 
 function setFromDate(date: DateTime | undefined) {
   if (date) {
-    ;(document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+    ;(document.getElementById('fromDate') as HTMLInputElement).value = date.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
   }
 }
 
 function setEndDate(date: DateTime | undefined) {
   if (date) {
-    ;(document.getElementById('toDate') as HTMLInputElement).value = date.toFormat('dd/LL/yyyy')
+    ;(document.getElementById('toDate') as HTMLInputElement).value = date.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
   }
 }
 

--- a/src/client-side/datetime-picker.ts
+++ b/src/client-side/datetime-picker.ts
@@ -1,15 +1,15 @@
-declare const $: JQueryStatic
+declare const $: JQueryStatic | undefined
 
 const initDateTimePicker = () => {
   const datePicker = () => {
-    $('.date-picker').datepicker({
+    $!('.date-picker').datepicker({
       format: 'dd/mm/yyyy',
       autoclose: true,
     })
   }
 
   const timePicker = () => {
-    $('.time-picker').timepicker({
+    $!('.time-picker').timepicker({
       showDuration: true,
       timeFormat: 'G:i:s',
       roundingFunction: () => null,
@@ -17,15 +17,17 @@ const initDateTimePicker = () => {
   }
 
   const datePair = () => {
-    $('.datetime-pair').datepair({
+    $!('.datetime-pair').datepair({
       dateClass: 'date-picker',
       timeClass: 'time-picker',
     })
   }
 
-  datePicker()
-  timePicker()
-  datePair()
+  if (Object.hasOwn(window, '$') && $) {
+    datePicker()
+    timePicker()
+    datePair()
+  }
 }
 
 export default initDateTimePicker

--- a/src/client-side/datetime-picker.ts
+++ b/src/client-side/datetime-picker.ts
@@ -1,9 +1,10 @@
-/* global $ */
+declare const $: JQueryStatic
+
 const initDateTimePicker = () => {
   const datePicker = () => {
     $('.date-picker').datepicker({
       format: 'dd/mm/yyyy',
-      autoclose: true
+      autoclose: true,
     })
   }
 
@@ -11,14 +12,14 @@ const initDateTimePicker = () => {
     $('.time-picker').timepicker({
       showDuration: true,
       timeFormat: 'G:i:s',
-      roundingFunction: () => null
+      roundingFunction: () => null,
     })
   }
 
   const datePair = () => {
     $('.datetime-pair').datepair({
       dateClass: 'date-picker',
-      timeClass: 'time-picker'
+      timeClass: 'time-picker',
     })
   }
 

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -6,8 +6,9 @@ import {
   PaymentStatusFilterMapping,
   RefundStatusFilterMapping,
 } from '@utils/simplified-account/services/transactions/status-filters'
-import { parseDateTime } from '@utils/time/parse-date-time'
+import { parseTransactionSearchDateTime } from '@utils/time/parse-date-time'
 import type { DateTime } from 'luxon'
+import { TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
 
 interface TransactionSearchQuery {
   cardholderName?: string
@@ -25,6 +26,7 @@ interface TransactionSearchQuery {
   toTime?: string
   includeTime?: string
   gatewayPayoutId?: string
+  jsEnabled?: string
 }
 
 export class TransactionSearchParams {
@@ -125,22 +127,37 @@ export class TransactionSearchParams {
       searchParams.brand = queryParams.brand.split(',')
     }
 
-    if (queryParams.fromDate || queryParams.toDate) {
-      searchParams.fromDate = parseDateTime(
+    const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
+
+    const isJsDateFilterSearch =
+      queryParams.jsEnabled !== 'false' && !queryParams.fromDate && !queryParams.toDate && queryParams.dateFilter
+    const isNoJsDateFilterSearch = queryParams.jsEnabled === 'false' && queryParams.dateFilter
+
+    if (!isJsDateFilterSearch && !isNoJsDateFilterSearch) {
+      searchParams.fromDate = parseTransactionSearchDateTime(
         queryParams.fromDate!,
         queryParams.fromTime!,
         queryParams.includeTime === 'include'
       )
 
       // parse end date/time, clamp to end of day if not including time
-      const toDate = parseDateTime(queryParams.toDate!, queryParams.toTime!, queryParams.includeTime === 'include')
+      const toDate = parseTransactionSearchDateTime(
+        queryParams.toDate!,
+        queryParams.toTime!,
+        queryParams.includeTime === 'include'
+      )
       searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')
 
-      searchParams.dateFilter = queryParams.dateFilter
+      // if the selected dates match the filter, persist the filter, otherwise set to custom-range
+      // this ensures the correct filter is displayed to the user
+      searchParams.dateFilter =
+        queryParams.fromDate === dateRange.start?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT) &&
+        queryParams.toDate === dateRange.end?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
+          ? queryParams.dateFilter
+          : 'custom-range'
+
       searchParams.includeTime = queryParams.includeTime === 'include'
     } else if (queryParams.dateFilter) {
-      const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
-
       searchParams.dateFilter = queryParams.dateFilter
       searchParams.fromDate = dateRange.start
       searchParams.toDate = dateRange.end

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -135,15 +135,15 @@ export class TransactionSearchParams {
 
     if (!isJsDateFilterSearch && !isNoJsDateFilterSearch) {
       searchParams.fromDate = parseTransactionSearchDateTime(
-        queryParams.fromDate!,
-        queryParams.fromTime!,
+        queryParams.fromDate ?? '',
+        queryParams.fromTime ?? '',
         queryParams.includeTime === 'include'
       )
 
       // parse end date/time, clamp to end of day if not including time
       const toDate = parseTransactionSearchDateTime(
-        queryParams.toDate!,
-        queryParams.toTime!,
+        queryParams.toDate ?? '',
+        queryParams.toTime ?? '',
         queryParams.includeTime === 'include'
       )
       searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -203,8 +203,8 @@ const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearch
   const isJsEnabled = queryParams.jsEnabled !== 'false'
   const isDateFilterValidPeriod = TRANSACTION_FILTER_PERIODS.has(queryParams.dateFilter as Period)
 
-  // with JS enabled, override the selected filter if any dates are entered
-  const isJsDateFilterSearch = isJsEnabled && !queryParams.fromDate && !queryParams.toDate && isDateFilterValidPeriod
+  const isDateRangeEntered = Boolean(queryParams.fromDate) || Boolean(queryParams.toDate)
+  const isJsDateFilterSearch = isJsEnabled && !isDateRangeEntered && isDateFilterValidPeriod
   // with JS disabled, override any entered dates & times if the filter is valid
   const isNoJsDateFilterSearch = !isJsEnabled && isDateFilterValidPeriod
 
@@ -237,8 +237,7 @@ const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearch
     // if the selected dates match the filter, persist the filter, otherwise set to custom-range
     // this ensures the correct filter is displayed to the user
     searchParams.dateFilter =
-      queryParams.fromDate === dateRange.start?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT) &&
-      queryParams.toDate === dateRange.end?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
+      isSameDate(queryParams.fromDate, dateRange.start) && isSameDate(queryParams.toDate, dateRange.end)
         ? queryParams.dateFilter
         : 'custom-range'
 
@@ -246,4 +245,8 @@ const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearch
   }
 
   return searchParams
+}
+
+function isSameDate(dateString: string | undefined, date: DateTime | undefined) {
+  return dateString === date?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
 }

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -1,5 +1,9 @@
 import { ConnectorStates } from '@models/transaction/types/status'
-import { getPeriodUKDateTimeRange, Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import {
+  getPeriodUKDateTimeRange,
+  Period,
+  TRANSACTION_FILTER_PERIODS,
+} from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { TransactionSearchParamsData } from '@models/transaction/dto/TransactionSearchParams.dto'
 import {
   DisputeStatusFilterMapping,
@@ -9,6 +13,7 @@ import {
 import { parseTransactionSearchDateTime } from '@utils/time/parse-date-time'
 import type { DateTime } from 'luxon'
 import { TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
+import { TimeConstants } from '@utils/time/time-constants'
 
 interface TransactionSearchQuery {
   cardholderName?: string
@@ -44,8 +49,8 @@ export class TransactionSearchParams {
   email?: string
   type?: string
   dateFilter?: string
-  fromDate?: DateTime
-  toDate?: DateTime
+  fromDate?: DateTime<true>
+  toDate?: DateTime<true>
   state?: string[]
   paymentStates?: string[]
   refundStates?: string[]
@@ -127,42 +132,7 @@ export class TransactionSearchParams {
       searchParams.brand = queryParams.brand.split(',')
     }
 
-    const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
-
-    const isJsDateFilterSearch =
-      queryParams.jsEnabled !== 'false' && !queryParams.fromDate && !queryParams.toDate && queryParams.dateFilter
-    const isNoJsDateFilterSearch = queryParams.jsEnabled === 'false' && queryParams.dateFilter
-
-    if (!isJsDateFilterSearch && !isNoJsDateFilterSearch) {
-      searchParams.fromDate = parseTransactionSearchDateTime(
-        queryParams.fromDate ?? '',
-        queryParams.fromTime ?? '',
-        queryParams.includeTime === 'include'
-      )
-
-      // parse end date/time, clamp to end of day if not including time
-      const toDate = parseTransactionSearchDateTime(
-        queryParams.toDate ?? '',
-        queryParams.toTime ?? '',
-        queryParams.includeTime === 'include'
-      )
-      searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')
-
-      // if the selected dates match the filter, persist the filter, otherwise set to custom-range
-      // this ensures the correct filter is displayed to the user
-      searchParams.dateFilter =
-        queryParams.fromDate === dateRange.start?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT) &&
-        queryParams.toDate === dateRange.end?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
-          ? queryParams.dateFilter
-          : 'custom-range'
-
-      searchParams.includeTime = queryParams.includeTime === 'include'
-    } else if (queryParams.dateFilter) {
-      searchParams.dateFilter = queryParams.dateFilter
-      searchParams.fromDate = dateRange.start
-      searchParams.toDate = dateRange.end
-      searchParams.includeTime = false
-    }
+    Object.assign(searchParams, processDateAndTime(queryParams))
 
     if (queryParams.state) {
       const stateFilters = convertStateFilter(queryParams.state)
@@ -215,4 +185,65 @@ function parsePageNumber(pageNumber?: string) {
 
 const nonEmpty = (value: string | undefined) => {
   return value === '' ? undefined : value
+}
+
+interface DateTimeSearchParams {
+  dateFilter?: string
+  fromDate?: DateTime<true>
+  toDate?: DateTime<true>
+  fromTime?: string
+  toTime?: string
+  includeTime?: boolean
+}
+
+const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearchParams => {
+  const searchParams: DateTimeSearchParams = {}
+
+  const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
+  const isJsEnabled = queryParams.jsEnabled !== 'false'
+  const isDateFilterValidPeriod = TRANSACTION_FILTER_PERIODS.has(queryParams.dateFilter as Period)
+
+  // with JS enabled, override the selected filter if any dates are entered
+  const isJsDateFilterSearch = isJsEnabled && !queryParams.fromDate && !queryParams.toDate && isDateFilterValidPeriod
+  // with JS disabled, override any entered dates & times if the filter is valid
+  const isNoJsDateFilterSearch = !isJsEnabled && isDateFilterValidPeriod
+
+  if (isJsDateFilterSearch || isNoJsDateFilterSearch) {
+    searchParams.dateFilter = queryParams.dateFilter
+    searchParams.fromDate = dateRange.start
+    searchParams.toDate = dateRange.end
+    searchParams.includeTime = false
+
+    return searchParams
+  }
+
+  if (queryParams.fromDate || queryParams.toDate) {
+    searchParams.fromDate = parseTransactionSearchDateTime(
+      queryParams.fromDate ?? '',
+      queryParams.fromTime ?? '',
+      queryParams.includeTime === 'include',
+      TimeConstants.TWELVE_MONTHS_AGO
+    )
+
+    // parse end date/time, clamp to end of day if not including time
+    const toDate = parseTransactionSearchDateTime(
+      queryParams.toDate ?? '',
+      queryParams.toTime ?? '',
+      queryParams.includeTime === 'include',
+      TimeConstants.END_OF_TODAY
+    )
+    searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')
+
+    // if the selected dates match the filter, persist the filter, otherwise set to custom-range
+    // this ensures the correct filter is displayed to the user
+    searchParams.dateFilter =
+      queryParams.fromDate === dateRange.start?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT) &&
+      queryParams.toDate === dateRange.end?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
+        ? queryParams.dateFilter
+        : 'custom-range'
+
+    searchParams.includeTime = queryParams.includeTime === 'include'
+  }
+
+  return searchParams
 }

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -38,7 +38,7 @@ export class TransactionSearchParamsData {
     this.reference = params.reference ?? undefined
     this.email = params.email ?? undefined
     this.from_date = this.setFromDate(params) ?? undefined
-    this.to_date = params.toDate?.isValid ? params.toDate.toUTC().toISO()! : undefined
+    this.to_date = params.toDate?.isValid ? params.toDate.toUTC().toISO() : undefined
     this.payment_states = params.paymentStates?.map(toLower).join(',')
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -95,3 +95,15 @@ export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRa
       }
   }
 }
+
+export function dateRangeAsPeriod(fromDate: string, toDate: string, dateFormat?: string): Period | undefined {
+  const format = dateFormat ?? 'dd/LL/yyyy'
+
+  const periods: Period[] = ['today', 'yesterday', 'previous-month', 'last-12-months', 'all-time']
+
+  return periods.find((period) => {
+    const range = getPeriodUKDateTimeRange(period)
+
+    return range.start?.toFormat(format) === fromDate && range.end?.toFormat(format) === toDate
+  })
+}

--- a/src/utils/time/parse-date-time.test.ts
+++ b/src/utils/time/parse-date-time.test.ts
@@ -56,7 +56,7 @@ describe('date and time parsing tests', () => {
           const parsed = parseTransactionSearchDateTime('notadate', '13:42:00', false, defaultTime)
           parsed.should.not.be.null
           parsed.isValid.should.be.true
-          expect(parsed.toISO()).to.equal('2025-09-12T11:47:32.980+01:00')
+          expect(parsed.toUTC().toISO()).to.equal('2025-09-12T10:47:32.980Z')
         })
       })
 
@@ -67,7 +67,7 @@ describe('date and time parsing tests', () => {
           const parsed = parseTransactionSearchDateTime('01/06/2027', 'notatime', true, defaultTime)
           parsed.should.not.be.null
           parsed.isValid.should.be.true
-          expect(parsed.toISO()).to.equal('2025-09-12T11:47:32.980+01:00')
+          expect(parsed.toUTC().toISO()).to.equal('2025-09-12T10:47:32.980Z')
         })
       })
     })

--- a/src/utils/time/parse-date-time.test.ts
+++ b/src/utils/time/parse-date-time.test.ts
@@ -1,4 +1,4 @@
-import { parseDateTime } from '@utils/time/parse-date-time'
+import { parseTransactionSearchDateTime } from '@utils/time/parse-date-time'
 import { expect } from 'chai'
 
 const JANUARY_FIRST_2027 = '2027-01-01T00:00:00.000Z'
@@ -7,60 +7,62 @@ const JANUARY_FIRST_2027_NINE_SEVENTEEN_AM = '2027-01-01T09:17:00.000Z'
 const JUNE_FIRST_2027_ONE_FORTY_TWO_PM = '2027-06-01T12:42:00.000Z' // during BST, so UTC is one hour behind
 
 describe('date and time parsing tests', () => {
-  describe('Parsing Dates only', () => {
-    it('should correctly parse a date if a time is not provided includeTime is false', () => {
-      const parsed = parseDateTime('01/01/2027', '', false)
-      parsed.should.not.be.null
-      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
-    })
-
-    it('should correctly parse a date if a time is not provided and includeTime is true', () => {
-      const parsed = parseDateTime('01/01/2027', '', true)
-      parsed.should.not.be.null
-      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
-    })
-
-    it('should correctly parse a date if a time is provided and includeTime is false', () => {
-      const parsed = parseDateTime('01/01/2027', '09:17:00', false)
-      parsed.should.not.be.null
-      parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
-    })
-  })
-
-  describe('parsing dates with times', () => {
-    describe('Parsing dates with GMT times', () => {
-      it('should correctly parse a date with time during GMT', () => {
-        const parsed = parseDateTime('01/01/2027', '9:17:00', true)
+  describe('transactions search date/time parsing', () => {
+    describe('Parsing Dates only', () => {
+      it('should correctly parse a date if a time is not provided includeTime is false', () => {
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '', false)
         parsed.should.not.be.null
-        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+      })
+
+      it('should correctly parse a date if a time is not provided and includeTime is true', () => {
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '', true)
+        parsed.should.not.be.null
+        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+      })
+
+      it('should correctly parse a date if a time is provided and includeTime is false', () => {
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '09:17:00', false)
+        parsed.should.not.be.null
+        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
       })
     })
 
-    describe('Parsing dates with BST times', () => {
-      it('should correctly parse a date with time during BST', () => {
-        const parsed = parseDateTime('01/06/2027', '13:42:00', true)
-        parsed.should.not.be.null
-        parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+    describe('parsing dates with times', () => {
+      describe('Parsing dates with GMT times', () => {
+        it('should correctly parse a date with time during GMT', () => {
+          const parsed = parseTransactionSearchDateTime('01/01/2027', '9:17:00', true)
+          parsed.should.not.be.null
+          parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+        })
+      })
+
+      describe('Parsing dates with BST times', () => {
+        it('should correctly parse a date with time during BST', () => {
+          const parsed = parseTransactionSearchDateTime('01/06/2027', '13:42:00', true)
+          parsed.should.not.be.null
+          parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+        })
       })
     })
-  })
 
-  describe('parsing invalid dates and times', () => {
-    describe('for an invalid date', () => {
-      it('should return a DateTime with isValid false', () => {
-        const parsed = parseDateTime('notadate', '13:42:00', false)
-        parsed.should.not.be.null
-        parsed.isValid.should.be.false
-        expect(parsed.toISO()).to.be.null
+    describe('parsing invalid dates and times', () => {
+      describe('for an invalid date', () => {
+        it('should return a DateTime with isValid false', () => {
+          const parsed = parseTransactionSearchDateTime('notadate', '13:42:00', false)
+          parsed.should.not.be.null
+          parsed.isValid.should.be.false
+          expect(parsed.toISO()).to.be.null
+        })
       })
-    })
 
-    describe('for an invalid time', () => {
-      it('should return a DateTime with isValid false', () => {
-        const parsed = parseDateTime('01/06/2027', 'notatime', true)
-        parsed.should.not.be.null
-        parsed.isValid.should.be.false
-        expect(parsed.toISO()).to.be.null
+      describe('for an invalid time', () => {
+        it('should return a DateTime with isValid false', () => {
+          const parsed = parseTransactionSearchDateTime('01/06/2027', 'notatime', true)
+          parsed.should.not.be.null
+          parsed.isValid.should.be.false
+          expect(parsed.toISO()).to.be.null
+        })
       })
     })
   })

--- a/src/utils/time/parse-date-time.test.ts
+++ b/src/utils/time/parse-date-time.test.ts
@@ -1,5 +1,7 @@
 import { parseTransactionSearchDateTime } from '@utils/time/parse-date-time'
 import { expect } from 'chai'
+import { TimeConstants } from '@utils/time/time-constants'
+import { DateTime } from 'luxon'
 
 const JANUARY_FIRST_2027 = '2027-01-01T00:00:00.000Z'
 const JANUARY_FIRST_2027_NINE_SEVENTEEN_AM = '2027-01-01T09:17:00.000Z'
@@ -10,58 +12,62 @@ describe('date and time parsing tests', () => {
   describe('transactions search date/time parsing', () => {
     describe('Parsing Dates only', () => {
       it('should correctly parse a date if a time is not provided includeTime is false', () => {
-        const parsed = parseTransactionSearchDateTime('01/01/2027', '', false)
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '', false, TimeConstants.NOW)
         parsed.should.not.be.null
-        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+        parsed.toUTC().toISO().should.eq(JANUARY_FIRST_2027)
       })
 
       it('should correctly parse a date if a time is not provided and includeTime is true', () => {
-        const parsed = parseTransactionSearchDateTime('01/01/2027', '', true)
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '', true, TimeConstants.NOW)
         parsed.should.not.be.null
-        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+        parsed.toUTC().toISO().should.eq(JANUARY_FIRST_2027)
       })
 
       it('should correctly parse a date if a time is provided and includeTime is false', () => {
-        const parsed = parseTransactionSearchDateTime('01/01/2027', '09:17:00', false)
+        const parsed = parseTransactionSearchDateTime('01/01/2027', '09:17:00', false, TimeConstants.NOW)
         parsed.should.not.be.null
-        parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027)
+        parsed.toUTC().toISO().should.eq(JANUARY_FIRST_2027)
       })
     })
 
     describe('parsing dates with times', () => {
       describe('Parsing dates with GMT times', () => {
         it('should correctly parse a date with time during GMT', () => {
-          const parsed = parseTransactionSearchDateTime('01/01/2027', '9:17:00', true)
+          const parsed = parseTransactionSearchDateTime('01/01/2027', '9:17:00', true, TimeConstants.NOW)
           parsed.should.not.be.null
-          parsed.toUTC().toISO()!.should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
+          parsed.toUTC().toISO().should.eq(JANUARY_FIRST_2027_NINE_SEVENTEEN_AM)
         })
       })
 
       describe('Parsing dates with BST times', () => {
         it('should correctly parse a date with time during BST', () => {
-          const parsed = parseTransactionSearchDateTime('01/06/2027', '13:42:00', true)
+          const parsed = parseTransactionSearchDateTime('01/06/2027', '13:42:00', true, TimeConstants.NOW)
           parsed.should.not.be.null
-          parsed.toUTC().toISO()!.should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
+          parsed.toUTC().toISO().should.eq(JUNE_FIRST_2027_ONE_FORTY_TWO_PM)
         })
       })
     })
 
     describe('parsing invalid dates and times', () => {
       describe('for an invalid date', () => {
-        it('should return a DateTime with isValid false', () => {
-          const parsed = parseTransactionSearchDateTime('notadate', '13:42:00', false)
+        it('should return the passed default time', () => {
+          const defaultTime = DateTime.fromISO('2025-09-12T11:47:32.980+01:00') as DateTime<true>
+
+          const parsed = parseTransactionSearchDateTime('notadate', '13:42:00', false, defaultTime)
           parsed.should.not.be.null
-          parsed.isValid.should.be.false
-          expect(parsed.toISO()).to.be.null
+          parsed.isValid.should.be.true
+          expect(parsed.toISO()).to.equal('2025-09-12T11:47:32.980+01:00')
         })
       })
 
       describe('for an invalid time', () => {
         it('should return a DateTime with isValid false', () => {
-          const parsed = parseTransactionSearchDateTime('01/06/2027', 'notatime', true)
+          const defaultTime = DateTime.fromISO('2025-09-12T11:47:32.980+01:00') as DateTime<true>
+
+          const parsed = parseTransactionSearchDateTime('01/06/2027', 'notatime', true, defaultTime)
           parsed.should.not.be.null
-          parsed.isValid.should.be.false
-          expect(parsed.toISO()).to.be.null
+          parsed.isValid.should.be.true
+          expect(parsed.toISO()).to.equal('2025-09-12T11:47:32.980+01:00')
         })
       })
     })

--- a/src/utils/time/parse-date-time.ts
+++ b/src/utils/time/parse-date-time.ts
@@ -1,9 +1,10 @@
 import { DateTime } from 'luxon'
+import { TRANSACTION_SEARCH_DATE_TIME_FORMAT, TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
 
-export function parseDateTime(date: string, time: string, includeTime: boolean): DateTime {
+export function parseTransactionSearchDateTime(date: string, time: string, includeTime: boolean): DateTime {
   if (includeTime && time !== '') {
     const dateTime = `${date} ${time}`
-    return DateTime.fromFormat(dateTime, 'dd/LL/yyyy H:mm:ss', { zone: 'Europe/London' })
+    return DateTime.fromFormat(dateTime, TRANSACTION_SEARCH_DATE_TIME_FORMAT, { zone: 'Europe/London' })
   }
-  return DateTime.fromFormat(date, 'dd/LL/yyyy', { zone: 'Europe/London' })
+  return DateTime.fromFormat(date, TRANSACTION_SEARCH_DATE_FORMAT, { zone: 'Europe/London' })
 }

--- a/src/utils/time/parse-date-time.ts
+++ b/src/utils/time/parse-date-time.ts
@@ -1,10 +1,19 @@
 import { DateTime } from 'luxon'
 import { TRANSACTION_SEARCH_DATE_TIME_FORMAT, TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
 
-export function parseTransactionSearchDateTime(date: string, time: string, includeTime: boolean): DateTime {
+export function parseTransactionSearchDateTime(
+  date: string,
+  time: string,
+  includeTime: boolean,
+  defaultValue: DateTime<true>
+): DateTime<true> {
+  let parsed
   if (includeTime && time !== '') {
     const dateTime = `${date} ${time}`
-    return DateTime.fromFormat(dateTime, TRANSACTION_SEARCH_DATE_TIME_FORMAT, { zone: 'Europe/London' })
+    parsed = DateTime.fromFormat(dateTime, TRANSACTION_SEARCH_DATE_TIME_FORMAT, { zone: 'Europe/London' })
+  } else {
+    parsed = DateTime.fromFormat(date, TRANSACTION_SEARCH_DATE_FORMAT, { zone: 'Europe/London' })
   }
-  return DateTime.fromFormat(date, TRANSACTION_SEARCH_DATE_FORMAT, { zone: 'Europe/London' })
+
+  return parsed.isValid ? parsed : defaultValue
 }

--- a/src/utils/time/time-constants.ts
+++ b/src/utils/time/time-constants.ts
@@ -9,6 +9,18 @@ export class TimeConstants {
       .minus({ years: 1 }) as DateTime<true>
   }
 
+  static get TODAY(): DateTime<true> {
+    return DateTime.now().setLocale('en-GB').setZone('Europe/London').startOf('day') as DateTime<true>
+  }
+
+  static get END_OF_TODAY(): DateTime<true> {
+    return DateTime.now().setLocale('en-GB').setZone('Europe/London').endOf('day') as DateTime<true>
+  }
+
+  static get NOW(): DateTime<true> {
+    return DateTime.now().setLocale('en-GB').setZone('Europe/London') as DateTime<true>
+  }
+
   static get YESTERDAY(): DateTime<true> {
     return DateTime.now()
       .setLocale('en-GB')

--- a/src/utils/time/time-formats.ts
+++ b/src/utils/time/time-formats.ts
@@ -1,0 +1,5 @@
+export const TRANSACTION_SEARCH_DATE_FORMAT = 'dd/LL/yyyy'
+
+export const TRANSACTION_SEARCH_TIME_FORMAT = 'H:mm:ss'
+
+export const TRANSACTION_SEARCH_DATE_TIME_FORMAT = 'dd/LL/yyyy H:mm:ss'

--- a/src/views/simplified-account/transactions/filter.njk
+++ b/src/views/simplified-account/transactions/filter.njk
@@ -52,11 +52,15 @@
     <div class="govuk-grid-column-one-third"> <br class="transactions-list__br" /></div>
   </div>
 
+  <!-- value will be updated to 'true' if JS is enabled -->
+  <input type="hidden" name="jsEnabled" value="false" id="js-enabled" />
+
   {% if filters.metadataValue or filters.agreementId %}
     {% set detailsElementOpenHtml = 'open="true"' %}
   {% endif %}
 </div>
 
+<!-- this is inlined to ensure it runs as soon as the filters are rendered -->
 <script>
   if (!document.getElementById('include-time-checkbox').checked) {
     document.getElementById('time-picker').hidden = true

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -227,7 +227,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           displaySize: 20,
-          filters: { from_date: DateTime.local(2025), to_date: DateTime.local(2026) },
+          filters: { from_date: '2025-01-01T00:00:00.000Z', to_date: '2026-01-01T23:59:59.999Z' },
           transactions: [TRANSACTION],
           transactionLength: 1,
         }),
@@ -236,12 +236,6 @@ describe('Transactions index', () => {
       cy.visit(TRANSACTIONS_LIST_URL)
 
       cy.get('.datepicker').should('not.exist')
-
-      cy.get('#fromDate').type('01/01/25')
-      cy.get('.datepicker').should('be.visible')
-
-      cy.get('#toDate').type('01/01/26')
-      cy.get('.datepicker').should('be.visible')
 
       cy.contains('Search transactions').click()
 
@@ -261,10 +255,18 @@ describe('Transactions index', () => {
         .find('th')
         .should('contain', unfilteredTransactions[2].reference)
 
-      cy.get('a').contains('Clear filter').click()
+      cy.get('#fromDate').type('01/01/2025')
+      cy.get('.datepicker').should('be.visible')
 
-      cy.get('#fromDate').should('be.empty')
-      cy.get('#toDate').should('be.empty')
+      cy.get('#toDate').type('01/01/2026')
+      cy.get('.datepicker').should('be.visible')
+
+      cy.get('.govuk-button').contains('Search transactions').click()
+
+      cy.get('#transactions-list tbody').find('tr').first().find('th').should('contain', TRANSACTION.reference)
+
+      cy.get('#fromDate').should('have.value', '01/01/2025')
+      cy.get('#toDate').should('have.value', '01/01/2026')
     })
 
     it('should be able to filter using date ranges', () => {

--- a/types/jquery-datepair/index.d.ts
+++ b/types/jquery-datepair/index.d.ts
@@ -1,0 +1,8 @@
+interface DatePairOptions {
+  dateClass?: string
+  timeClass?: string
+}
+
+interface JQuery {
+  datepair(options?: DatePairOptions): JQuery
+}

--- a/types/jquery-timepicker/index.d.ts
+++ b/types/jquery-timepicker/index.d.ts
@@ -1,0 +1,9 @@
+interface TimePickerOptions {
+  showDuration?: boolean
+  timeFormat?: string
+  roundingFunction?: (...params: unknown[]) => unknown
+}
+
+interface JQuery {
+  timepicker(options?: TimePickerOptions): JQuery
+}


### PR DESCRIPTION
## What

PP-15481
improve consistency between selected date range filters and the displayed to/from dates

when using Javascript:
- choosing a date in the date picker will update the date range filter
 - if the entered dates conform to one of the possible date ranges, this will be selected
   - otherwise, it will default to `Between two dates`
   - this will update on-the-fly with client-side JS

When not using Javascript:
- selecting a valid filter will take priority over entered dates
- as with JS version, if the entered dates conform to one of the possible date ranges, this will be selected
  - this will happen when the form is submitted and the page reloads

A `jsEnabled` hidden input is added to identify if the search is performed with JS enabled or disabled, and handle the search accordingly. This allows for tuning the way dates are handled in each case.

Additional changes:
 - Extract date and time parsing code in `TransactionSearchParams` with aim of improving clarity & readability
   - this is also partially rewritten and additional comments added to improve readability
 - enforce computed dates in `TransactionSearchParams` are always valid by using default values in parsing dates & times
 - This also adds some types for JQuery and JQuery utils, and converts some client-side code to Typescript. 