### PR TITLE
PP-15440 Add Your provider is changing link to dashboard and navigation

### DIFF
--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -6,13 +6,13 @@ import formatAccountPathsFor from '@utils/format-account-paths-for'
 import paths from '@root/paths'
 import formatServicePathsFor from '@utils/format-service-paths-for'
 import {
-  possibleActions,
+  getAccountStatus,
   getActionsToDisplay,
+  getConfigurePSPAccountLink,
   getGoLiveStatus,
   getTelephonePaymentLink,
   isWorldpayTestService,
-  getConfigurePSPAccountLink,
-  getAccountStatus,
+  possibleActions,
 } from '@utils/simplified-account/services/dashboard/actions-utils'
 import createLogger from '@utils/logger'
 import type { DateTime } from 'luxon'
@@ -101,6 +101,11 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
         requestPspTestAccount: formatServicePathsFor(paths.service.requestPspTestAccount, req.service.externalId),
         requestLiveAccount: formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId),
         configurePSPAccount: getConfigurePSPAccountLink(req.service, req.account),
+        providerChangeToAdyen: formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.providerChangeToAdyen,
+          req.service.externalId,
+          req.account.type
+        ),
       },
     },
   })

--- a/src/utils/simplified-account/navigation/service-settings-navigation.ts
+++ b/src/utils/simplified-account/navigation/service-settings-navigation.ts
@@ -7,6 +7,7 @@ import Service from '@models/service/Service.class'
 import { LIVE } from '@models/constants/go-live-stage'
 import UserPermissions from '@models/user/permissions'
 import GatewayAccountType from '@models/gateway-account/gateway-account-type'
+import { Features } from '@root/config/features'
 
 export = (account: GatewayAccount, service: Service, currentUrl: string, permissions: Record<string, boolean>) => {
   const navBuilder = new NavigationBuilder(currentUrl, permissions)
@@ -100,6 +101,20 @@ export = (account: GatewayAccount, service: Service, currentUrl: string, permiss
       ),
       hasPermission: UserPermissions.settings.gatewayCredentials.gatewayCredentialsUpdate,
       conditions: account.isSwitchingToProvider(STRIPE),
+    })
+    .add({
+      id: 'provider-change-to-adyen',
+      name: 'Your provider is changing to Adyen',
+      path: formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.switchPsp.switchToAdyen.providerChangeToAdyen,
+        service.externalId,
+        account.type
+      ),
+      hasPermission: UserPermissions.settings.stripe.stripeAccountDetailsUpdate,
+      conditions:
+        account.paymentProvider === STRIPE &&
+        account.type === GatewayAccountType.LIVE &&
+        Features.isProviderChangeToAdyenLinkEnabled(),
     })
     .category('payments', { collapsible: true })
     .add({

--- a/src/utils/simplified-account/services/dashboard/actions-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/actions-utils.ts
@@ -12,6 +12,7 @@ import CredentialState from '@models/constants/credential-state'
 import { getConnectorStripeAccountSetup, getStripeAccountCapabilities } from '@services/stripe-details.service'
 import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 import { ProductType } from '@models/products/product-type'
+import { Features } from '@root/config/features'
 
 const logger = createLogger(__filename)
 
@@ -23,6 +24,7 @@ const possibleActions = {
   goLive: 4,
   telephonePaymentLink: 5,
   switchMode: 6,
+  displayProviderChangeToAdyen: 7,
 }
 
 const goLiveStartedStages = [
@@ -92,6 +94,14 @@ const getTelephonePaymentLink = async (user: User, service: Service, gatewayAcco
   return undefined
 }
 
+function isALiveStripeServiceAndAdminUser(service: Service, account: GatewayAccount, user: User) {
+  return (
+    account.type === GatewayAccountType.LIVE &&
+    account.paymentProvider === PaymentProviders.STRIPE &&
+    user.hasPermission(service.externalId, 'stripe-account-details:update')
+  )
+}
+
 const getActionsToDisplay = (
   service: Service,
   account: GatewayAccount,
@@ -121,6 +131,10 @@ const getActionsToDisplay = (
 
   if (displaySwitchMode(service, account)) {
     actionsToDisplay.push(possibleActions.switchMode)
+  }
+
+  if (isALiveStripeServiceAndAdminUser(service, account, user) && Features.isProviderChangeToAdyenLinkEnabled()) {
+    actionsToDisplay.push(possibleActions.displayProviderChangeToAdyen)
   }
 
   return actionsToDisplay

--- a/src/views/simplified-account/services/dashboard/partials/_links.njk
+++ b/src/views/simplified-account/services/dashboard/partials/_links.njk
@@ -11,6 +11,17 @@
   data-click-action="First steps link clicked"
 >
   <div class="flex-grid--row">
+    {% if possibleActions.displayProviderChangeToAdyen in dashboardActions %}
+      <article class="{{ columnClass }} links__box" id="switch-to-adyen-info">
+        <a id="provider-change-to-adyen-link" href="{{ links.dashboardActions.providerChangeToAdyen }}">
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Your provider is changing to Adyen</h2>
+          <p class="govuk-body govuk-!-margin-bottom-0">
+            All services are moving from Stripe to Adyen by the end of 2026. Find out everything you need to know and
+            what you’ll need to do.
+          </p>
+        </a>
+      </article>
+    {% endif %}
     {% if possibleActions.switchMode in dashboardActions %}
       <article class="{{ columnClass }} links__box" id="switch-mode">
         <a href="{{ links.dashboardActions.switchMode }}">

--- a/test/cypress/integration/dashboard/dashboard-links.cy.js
+++ b/test/cypress/integration/dashboard/dashboard-links.cy.js
@@ -69,6 +69,8 @@ describe('the links are displayed correctly on the dashboard', () => {
 
       cy.get('#test-payment-link-link').should('exist')
       cy.get('#test-payment-link-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#provider-change-to-adyen-link').should('not.exist')
     })
 
     it('should display 2 links for a live service in live mode', () => {
@@ -86,6 +88,19 @@ describe('the links are displayed correctly on the dashboard', () => {
 
       cy.get('#payment-links-link').should('exist')
       cy.get('#payment-links-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#provider-change-to-adyen-link').should('not.exist')
+    })
+
+    it('should display "Your provider is changing to Adyen" link for a Stripe live account', () => {
+      cy.task(
+        'setupStubs',
+        getStubsForDashboard(gatewayAccountId, GatewayAccountType.LIVE, PaymentProviders.STRIPE, GoLiveStage.LIVE)
+      )
+
+      cy.visit(dashboardUrl(GatewayAccountType.LIVE))
+
+      cy.get('#provider-change-to-adyen-link').should('exist')
     })
 
     it('should display 3 links for a test sandbox account created since onboarding flow changed on 29/08/2024', () => {
@@ -164,6 +179,8 @@ describe('the links are displayed correctly on the dashboard', () => {
 
       cy.get('#request-to-go-live-link').should('exist')
       cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-half')
+
+      cy.get('#provider-change-to-adyen-link').should('not.exist')
     })
 
     it('should display 3 links (demo payment, test with users and request to go live) for a Stripe test account', () => {
@@ -188,6 +205,8 @@ describe('the links are displayed correctly on the dashboard', () => {
 
       cy.get('#request-to-go-live-link').should('exist')
       cy.get('#request-to-go-live-link').should('have.class', 'flex-grid--column-third')
+
+      cy.get('#provider-change-to-adyen-link').should('not.exist')
     })
   })
 })

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/provider-change-to-adyen.controller.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/provider-change-to-adyen.controller.cy.js
@@ -1,3 +1,4 @@
+const checkSettingsNavigation = require('@test/cypress/integration/simplified-account/service-settings/helpers/check-settings-nav')
 const userStubs = require('@test/cypress/stubs/user-stubs')
 const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
 const { STRIPE, WORLDPAY } = require('@models/constants/payment-providers')
@@ -52,6 +53,9 @@ describe('Switch to Adyen info', () => {
         })
         cy.visit(PROVIDER_CHANGE_TO_ADYEN, { failOnStatusCode: false })
         cy.title().should('contain', 'Your provider is changing to Adyen')
+
+        const PROVIDER_CHANGE_TO_ADYEN_URL = `/service/${SERVICE_EXTERNAL_ID}/account/live/settings/switch-psp/switch-to-adyen/provider-change-to-adyen`
+        checkSettingsNavigation('Your provider is changing to Adyen', PROVIDER_CHANGE_TO_ADYEN_URL)
       })
       it('should show error page to non-admin user', () => {
         setStubs({


### PR DESCRIPTION
## What
- Makes the link `Your provider is changing to Adyen` available on Dashboard and settings navigation for Stripe admin users and when the flag is enabled.

### - Dashboard

<img width="937" height="303" alt="image" src="https://github.com/user-attachments/assets/5ed84c00-ffb4-4ed2-8a2c-7fbf409207a9" />


### - Navigation

<img width="980" height="462" alt="image" src="https://github.com/user-attachments/assets/0f335af1-bab5-4558-9075-2aad1d9fa181" />

