### PR TITLE
PP-15481 Fix CSV download display

### DIFF
--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -71,7 +71,11 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const downloadQueryString = transactionSearchParams.getQueryParams().toString()
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
-  const hasQueryParams = transactionSearchParams.getQueryParams().toString().length
+
+  const userSelectedFilters = new URLSearchParams(transactionSearchParams.getQueryParams());
+  userSelectedFilters.delete("page");
+
+  const hasQueryParams = userSelectedFilters.toString().length
   const showCsvDownload =
     transactionCountWithinRange || (hasQueryParams && results.total > LEDGER_TRANSACTION_COUNT_LIMIT)
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -72,8 +72,8 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 
-  const userSelectedFilters = new URLSearchParams(transactionSearchParams.getQueryParams());
-  userSelectedFilters.delete("page");
+  const userSelectedFilters = new URLSearchParams(transactionSearchParams.getQueryParams())
+  userSelectedFilters.delete('page')
 
   const hasQueryParams = userSelectedFilters.toString().length
   const showCsvDownload =

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -72,10 +72,9 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 
-  const showCsvDownload = transactionCountWithinRange || (
-    transactionSearchParams.hasUserSelectedFilters() &&
-    results.total > LEDGER_TRANSACTION_COUNT_LIMIT
-  )
+  const showCsvDownload =
+    transactionCountWithinRange ||
+    (transactionSearchParams.hasUserSelectedFilters() && results.total > LEDGER_TRANSACTION_COUNT_LIMIT)
 
   req.session.transactionFilters = req.url.split('?')[1] || ''
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -72,12 +72,10 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 
-  const userSelectedFilters = new URLSearchParams(transactionSearchParams.getQueryParams())
-  userSelectedFilters.delete('page')
-
-  const hasQueryParams = userSelectedFilters.toString().length
-  const showCsvDownload =
-    transactionCountWithinRange || (hasQueryParams && results.total > LEDGER_TRANSACTION_COUNT_LIMIT)
+  const showCsvDownload = transactionCountWithinRange || (
+    transactionSearchParams.hasUserSelectedFilters() &&
+    results.total > LEDGER_TRANSACTION_COUNT_LIMIT
+  )
 
   req.session.transactionFilters = req.url.split('?')[1] || ''
 

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -83,6 +83,12 @@ export class TransactionSearchParams {
       .sort()
   }
 
+  hasUserSelectedFilters() {
+    const filters = this.getQueryParams()
+    filters.delete('page')
+    return filters.toString().length > 0
+  }
+
   static forAgreement(gatewayAccountId: number, agreementExternalId: string, currentPage: number, displaySize: number) {
     const searchParams = new TransactionSearchParams([gatewayAccountId], true)
     searchParams.page = currentPage

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -825,7 +825,7 @@ describe('Transactions index', () => {
 
       cy.visit(
         TRANSACTIONS_LIST_URL +
-        `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
+          `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
       )
 
       cy.get('.govuk-pagination__next').first().click()
@@ -843,7 +843,6 @@ describe('Transactions index', () => {
         transactions: [TRANSACTION],
         filters: {
           from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-
         },
         displaySize: 20,
         transactionLength: 6000,
@@ -915,7 +914,7 @@ describe('Transactions index', () => {
 
       cy.visit(
         TRANSACTIONS_LIST_URL +
-        `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
+          `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
       )
 
       cy.get('.govuk-button--secondary').contains('Download CSV').should('exist')

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -825,7 +825,7 @@ describe('Transactions index', () => {
 
       cy.visit(
         TRANSACTIONS_LIST_URL +
-          `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
+        `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
       )
 
       cy.get('.govuk-pagination__next').first().click()
@@ -835,6 +835,102 @@ describe('Transactions index', () => {
       cy.get('#lastDigitsCardNumber').invoke('val').should('contain', lastFourDigits)
       cy.get('#state').invoke('text').should('contain', 'Success')
       cy.get('#card-brand').invoke('text').should('contain', 'Visa')
+    })
+
+    it('should not display CSV download link on subsequent pages if transaction count is over limit', () => {
+      const ledgerTransactionsParams = {
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        transactions: [TRANSACTION],
+        filters: {
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+
+        },
+        displaySize: 20,
+        transactionLength: 6000,
+      }
+
+      cy.task('setupStubs', [
+        getLedgerTransactionsSuccess({
+          ...ledgerTransactionsParams,
+          page: 1,
+        }),
+        getLedgerTransactionsSuccess({
+          ...ledgerTransactionsParams,
+          page: 2,
+        }),
+      ])
+
+      cy.visit(TRANSACTIONS_LIST_URL)
+
+      cy.get('.govuk-button--secondary').contains('Download CSV').should('not.exist')
+      cy.get('#csv-download').should('contain', 'Filter results to download a CSV of transactions')
+      cy.get('[data-cy=pagination-detail]').contains(
+        `Over ${LEDGER_TRANSACTION_COUNT_LIMIT.toLocaleString()} transactions`
+      )
+
+      cy.get('.govuk-pagination__next').first().click()
+
+      cy.get('.govuk-button--secondary').contains('Download CSV').should('not.exist')
+      cy.get('#csv-download').should('contain', 'Filter results to download a CSV of transactions')
+      cy.get('[data-cy=pagination-detail]').contains(
+        `Over ${LEDGER_TRANSACTION_COUNT_LIMIT.toLocaleString()} transactions`
+      )
+    })
+
+    it('should display CSV download link subsequent pages if transaction count is over limit but filters are applied', () => {
+      const reference = TRANSACTION.reference
+      const email = TRANSACTION.email
+      const cardholderName = TRANSACTION.card_details?.cardholder_name
+      const cardholderNameSearchParam = cardholderName!.split(' ').join('+')
+      const transactionState = TRANSACTION.state?.status.toLowerCase()
+      const lastFourDigits = TRANSACTION.card_details?.last_digits_card_number
+      const cardBrands = 'visa'
+
+      const ledgerTransactionsParams = {
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        transactions: [TRANSACTION],
+        filters: {
+          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+          reference,
+          email,
+          cardholder_name: cardholderNameSearchParam,
+          payment_states: transactionState,
+          last_digits_card_number: lastFourDigits,
+          card_brands: cardBrands,
+        },
+        displaySize: 20,
+        transactionLength: 6000,
+      }
+
+      cy.task('setupStubs', [
+        getLedgerTransactionsSuccess({
+          ...ledgerTransactionsParams,
+          page: 1,
+        }),
+        getLedgerTransactionsSuccess({
+          ...ledgerTransactionsParams,
+          page: 2,
+        }),
+      ])
+
+      cy.visit(
+        TRANSACTIONS_LIST_URL +
+        `?reference=${reference}&email=${email}&cardholderName=${cardholderNameSearchParam}&lastDigitsCardNumber=${lastFourDigits}&brand=visa&state=success&page=1`
+      )
+
+      cy.get('.govuk-button--secondary').contains('Download CSV').should('exist')
+      cy.get('#csv-download').should('not.exist')
+      cy.get('[data-cy=pagination-detail]').contains(
+        `Over ${LEDGER_TRANSACTION_COUNT_LIMIT.toLocaleString()} transactions`
+      )
+
+      cy.get('.govuk-pagination__next').first().click()
+
+      cy.get('.govuk-button--secondary').contains('Download CSV').should('exist')
+      cy.get('#csv-download').should('not.exist')
+      cy.get('[data-cy=pagination-detail]').contains(
+        `Over ${LEDGER_TRANSACTION_COUNT_LIMIT.toLocaleString()} transactions`
+      )
     })
   })
 })


### PR DESCRIPTION
## What

PP-15481

- Fixes a bug where the CSV download link is displayed on page 2+, even when transactions are over the max limit
- Achieved through removing `page` from the list of search params which are used to determine whether or not the link should be displayed
- Add Cypress tests for this logic


>
<img width="497" height="494" alt="Screenshot 2026-06-23 at 14 08 12" src="https://github.com/user-attachments/assets/2fefd6bc-552d-47f6-bb78-55a505f82b08" />

***

<img width="500" height="483" alt="Screenshot 2026-06-23 at 14 10 28" src="https://github.com/user-attachments/assets/1ba1fb97-cfa6-4d5b-9d4d-6d76ee8f4d66" />
