### PR TITLE
PP-15440 Add missing CSS class to email links

### DIFF
--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/provider-change.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/provider-change.njk
@@ -105,13 +105,17 @@
   </p>
   <p class="govuk-body">
     Get in touch with us if you’re interested by emailing
-    <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a>
+    <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk"
+      >govuk-pay-support@digital.cabinet-office.gov.uk</a
+    >
   </p>
 
   <h2 class="govuk-heading-m">Questions and support</h2>
   <p class="govuk-body">
     Email
-    <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a>
+    <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk"
+      >govuk-pay-support@digital.cabinet-office.gov.uk</a
+    >
     if you have questions about the change of provider.
   </p>
   <p class="govuk-body">


### PR DESCRIPTION
## What
- Added missing `govuk-link` class to email links
