### PR TITLE
PP-15481 Show paying user email for disputes in Transactions list 

### DIFF
--- a/src/models/transaction/TransactionDisplayValues.class.ts
+++ b/src/models/transaction/TransactionDisplayValues.class.ts
@@ -79,7 +79,7 @@ export class TransactionDisplayValues {
   }
 
   get email(): string {
-    return (this.isRefund ? this.transaction.paymentDetails!.email : this.transaction.email) ?? ''
+    return (this.isRefund || this.isDispute ? this.transaction.paymentDetails!.email : this.transaction.email) ?? ''
   }
 
   get paymentProvider(): string {

--- a/src/models/transaction/TransactionDisplayValues.class.ts
+++ b/src/models/transaction/TransactionDisplayValues.class.ts
@@ -79,7 +79,7 @@ export class TransactionDisplayValues {
   }
 
   get email(): string {
-    return (this.isRefund || this.isDispute ? this.transaction.paymentDetails!.email : this.transaction.email) ?? ''
+    return this.transaction.email ?? this.transaction.paymentDetails?.email ?? ''
   }
 
   get paymentProvider(): string {

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -14,7 +14,11 @@ import { PaymentDetailsFixture } from '@test/fixtures/transaction/payment-detail
 import { getLedgerTransactionsFailure, getLedgerTransactionsSuccess } from '@test/cypress/stubs/transaction-stubs'
 import { TimeConstants } from '@utils/time/time-constants'
 import { CardDetailsFixture } from '@test/fixtures/card-details/card-details.fixture'
-import { DISPUTE_LOST_DATA } from '@test/fixtures/transaction/fixture-data/dispute-fixture-data'
+import {
+  DISPUTE_LOST_DATA,
+  DISPUTE_NEEDS_RESPONSE_DATA,
+  DISPUTE_WON_DATA,
+} from '@test/fixtures/transaction/fixture-data/dispute-fixture-data'
 import { LEDGER_TRANSACTION_COUNT_LIMIT } from '@controllers/simplified-account/services/transactions/constants'
 
 const TRANSACTION = new TransactionFixture().toTransactionData()
@@ -448,17 +452,21 @@ describe('Transactions index', () => {
     describe('Disputes', () => {
       it('should display amounts correctly for dispute awaiting evidence', () => {
         sharedStubs('test', 'stripe')
-
-        const state = new TransactionStateFixture({ status: Status.NEEDS_RESPONSE })
-        const paymentDetails = new PaymentDetailsFixture({ cardDetails: new CardDetailsFixture({ cardBrand: 'Visa' }) })
-        const disputeTransaction = new TransactionFixture({
-          paymentDetails,
-          transactionType: ResourceType.DISPUTE,
-          state,
-        }).toTransactionData()
+        const transaction = new TransactionFixture({
+          fee: 100,
+          netAmount: 900,
+        })
+        const disputeTransaction = new TransactionFixture(DISPUTE_NEEDS_RESPONSE_DATA, {
+          paymentDetails: transaction.asPaymentDetailsFixture(),
+          reference: transaction.reference,
+          parentTransactionExternalId: transaction.externalId,
+        })
 
         cy.task('setupStubs', [
-          getTransactionsForGatewayAccount(GATEWAY_ACCOUNT_ID).success([TRANSACTION, disputeTransaction]),
+          getTransactionsForGatewayAccount(GATEWAY_ACCOUNT_ID).success([
+            transaction.toTransactionData(),
+            disputeTransaction.toTransactionData(),
+          ]),
         ])
 
         cy.visit(TRANSACTIONS_LIST_URL)
@@ -467,19 +475,19 @@ describe('Transactions index', () => {
 
         assertTransactionRow(
           0,
-          transactionWithFees.reference,
-          TRANSACTION_URL(transactionWithFees.transaction_id),
-          transactionWithFees.email!,
-          penceToPoundsWithCurrency(transactionWithFees.amount),
+          transaction.reference,
+          TRANSACTION_URL(transaction.externalId),
+          transaction.email!,
+          penceToPoundsWithCurrency(transaction.amount),
           'Visa',
           'Success'
         )
 
         assertTransactionRow(
           1,
-          disputeTransaction.reference,
-          TRANSACTION_URL(disputeTransaction.transaction_id),
-          disputeTransaction.email!,
+          transaction.reference,
+          TRANSACTION_URL(disputeTransaction.parentTransactionExternalId!),
+          transaction.email!,
           penceToPoundsWithCurrency(disputeTransaction.amount),
           'Visa',
           'Dispute awaiting evidence',
@@ -490,16 +498,20 @@ describe('Transactions index', () => {
 
       it('should display amounts correctly for dispute lost to user', () => {
         sharedStubs('test', 'stripe')
-        const transacion = new TransactionFixture({
+        const transaction = new TransactionFixture({
           fee: 100,
           netAmount: 900,
         })
-        const lostDisputeTransaction = new TransactionFixture(DISPUTE_LOST_DATA)
+        const lostDisputeTransaction = new TransactionFixture(DISPUTE_LOST_DATA, {
+          paymentDetails: transaction.asPaymentDetailsFixture(),
+          reference: transaction.reference,
+          parentTransactionExternalId: transaction.externalId,
+        })
 
         cy.task('setupStubs', [
           getTransactionsForGatewayAccount(GATEWAY_ACCOUNT_ID).success([
             lostDisputeTransaction.toTransactionData(),
-            transacion.toTransactionData(),
+            transaction.toTransactionData(),
           ]),
         ])
 
@@ -511,7 +523,7 @@ describe('Transactions index', () => {
           0,
           lostDisputeTransaction.reference,
           TRANSACTION_URL(lostDisputeTransaction.externalId),
-          lostDisputeTransaction.email!,
+          transaction.email!,
           '£10.00',
           'Visa',
           'Dispute lost to user',
@@ -521,9 +533,9 @@ describe('Transactions index', () => {
 
         assertTransactionRow(
           1,
-          transacion.reference,
-          TRANSACTION_URL(transacion.externalId),
-          transacion.email!,
+          transaction.reference,
+          TRANSACTION_URL(transaction.externalId),
+          transaction.email!,
           '£10.00',
           'Visa',
           'Success'
@@ -532,17 +544,21 @@ describe('Transactions index', () => {
 
       it('should display amounts correctly for a dispute won in the service’s favour', () => {
         sharedStubs('test', 'stripe')
-
-        const state = new TransactionStateFixture({ status: Status.WON })
-        const paymentDetails = new PaymentDetailsFixture({ cardDetails: new CardDetailsFixture({ cardBrand: 'Visa' }) })
-        const disputeTransaction = new TransactionFixture({
-          paymentDetails,
-          transactionType: ResourceType.DISPUTE,
-          state,
-        }).toTransactionData()
+        const transaction = new TransactionFixture({
+          fee: 100,
+          netAmount: 900,
+        })
+        const disputeTransaction = new TransactionFixture(DISPUTE_WON_DATA, {
+          paymentDetails: transaction.asPaymentDetailsFixture(),
+          reference: transaction.reference,
+          parentTransactionExternalId: transaction.externalId,
+        })
 
         cy.task('setupStubs', [
-          getTransactionsForGatewayAccount(GATEWAY_ACCOUNT_ID).success([TRANSACTION, disputeTransaction]),
+          getTransactionsForGatewayAccount(GATEWAY_ACCOUNT_ID).success([
+            transaction.toTransactionData(),
+            disputeTransaction.toTransactionData(),
+          ]),
         ])
 
         cy.visit(TRANSACTIONS_LIST_URL)
@@ -551,19 +567,19 @@ describe('Transactions index', () => {
 
         assertTransactionRow(
           0,
-          TRANSACTION.reference,
-          TRANSACTION_URL(TRANSACTION.transaction_id),
-          TRANSACTION.email!,
-          penceToPoundsWithCurrency(TRANSACTION.amount),
+          transaction.reference,
+          TRANSACTION_URL(transaction.externalId),
+          transaction.email!,
+          penceToPoundsWithCurrency(transaction.amount),
           'Visa',
           'Success'
         )
 
         assertTransactionRow(
           1,
-          disputeTransaction.reference,
-          TRANSACTION_URL(disputeTransaction.transaction_id),
-          disputeTransaction.email!,
+          transaction.reference,
+          TRANSACTION_URL(disputeTransaction.parentTransactionExternalId!),
+          transaction.email!,
           penceToPoundsWithCurrency(disputeTransaction.amount),
           'Visa',
           'Dispute won in your favour',

--- a/test/fixtures/transaction/fixture-data/dispute-fixture-data.ts
+++ b/test/fixtures/transaction/fixture-data/dispute-fixture-data.ts
@@ -29,6 +29,7 @@ const DISPUTE_NEEDS_RESPONSE_DATA: Partial<TransactionFixture> = {
   }),
   evidenceDueDate: BASE_FIXTURE.createdDate.plus({ month: 5 }),
   reason: Reason.FRAUDULENT,
+  email: undefined,
 }
 
 const DISPUTE_UNDER_REVIEW_DATA: Partial<TransactionFixture> = {
@@ -50,6 +51,7 @@ const DISPUTE_UNDER_REVIEW_DATA: Partial<TransactionFixture> = {
   }),
   evidenceDueDate: BASE_FIXTURE.createdDate.plus({ month: 5 }),
   reason: Reason.FRAUDULENT,
+  email: undefined,
 }
 
 const DISPUTE_WON_DATA: Partial<TransactionFixture> = {
@@ -71,6 +73,7 @@ const DISPUTE_WON_DATA: Partial<TransactionFixture> = {
   }),
   evidenceDueDate: BASE_FIXTURE.createdDate.plus({ month: 5 }),
   reason: Reason.FRAUDULENT,
+  email: undefined,
 }
 
 const PSP_DISPUTE_FEE = 2000
@@ -98,6 +101,7 @@ const DISPUTE_LOST_DATA: Partial<TransactionFixture> = {
   }),
   evidenceDueDate: BASE_FIXTURE.createdDate.plus({ month: 5 }),
   reason: Reason.FRAUDULENT,
+  email: undefined,
 }
 
 export { DISPUTE_NEEDS_RESPONSE_DATA, DISPUTE_UNDER_REVIEW_DATA, DISPUTE_WON_DATA, DISPUTE_LOST_DATA }

--- a/test/fixtures/transaction/transaction.fixture.ts
+++ b/test/fixtures/transaction/transaction.fixture.ts
@@ -124,4 +124,14 @@ export class TransactionFixture {
   toTransaction() {
     return new Transaction(this.toTransactionData())
   }
+
+  asPaymentDetailsFixture(): PaymentDetailsFixture {
+    return new PaymentDetailsFixture({
+      description: this.description,
+      reference: this.reference,
+      email: this.email,
+      transactionType: this.transactionType,
+      cardDetails: this.cardDetails,
+    })
+  }
 }


### PR DESCRIPTION
## What

PP-15481

- show paying user email for dispute transactions in Transactions list

### Screenshots (views have been added/changed)

Before:
<img width="942" height="651" alt="Screenshot 2026-06-25 at 14 20 17" src="https://github.com/user-attachments/assets/b5e5776e-f50d-471e-b278-b6a008d8378a" />

After:
<img width="944" height="649" alt="Screenshot 2026-06-25 at 14 20 53" src="https://github.com/user-attachments/assets/5c0f8401-dc1e-45a0-8079-be449b86838a" />

