### PR TITLE
PP-15526 Redirect to new transactions pages on feature flag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -633,7 +633,7 @@
         "filename": "test/cypress/integration/transactions/transaction-search.cy.js",
         "hashed_secret": "13f4f9188f0777d4d93a6ed585ee67fdacb47397",
         "is_verified": false,
-        "line_number": 220
+        "line_number": 237
       }
     ],
     "test/cypress/integration/user/change-sign-in-method.cy.js": [

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -137,7 +137,7 @@ function serviceIdPolyfill(accountId: string, viewMode: ViewMode): string {
       `Unable to determine service external ID from gateway account [${accountId}]. Gateway account is not attached to request.`
     )
   }
-  return gatewayAccount.serviceId!
+  return gatewayAccount.serviceId
 }
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {

--- a/src/middleware/simplified-account/transaction-redirect.middleware.ts
+++ b/src/middleware/simplified-account/transaction-redirect.middleware.ts
@@ -1,0 +1,97 @@
+import { NextFunction, Request, Response } from 'express'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import { Features } from '@root/config/features'
+import formatPathFor from '@utils/replace-params-in-path'
+import { NotFoundError } from '@root/errors'
+import Ledger from '@services/clients/ledger.client'
+import { userServicesContainsGatewayAccount } from '@utils/permissions'
+import { TransactionData } from '@models/transaction/dto/Transaction.dto'
+import { getGatewayAccountById } from '@services/gateway-accounts.service'
+import Service from '@models/service/Service.class'
+import { ServiceData } from '@models/service/dto/Service.dto'
+import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
+import { GatewayAccountData } from '@models/gateway-account/dto/GatewayAccount.dto'
+import createLogger from '@utils/logger'
+
+const logger = createLogger('transaction-redirect.middleware.ts')
+
+export function transactionRedirect(path: string) {
+  if (!Features.isEnabled(Features.TRANSACTIONS)) {
+    return (req: Request, res: Response, next: NextFunction) => {
+      return next()
+    }
+  }
+
+  return (req: Request & { service?: unknown; account?: unknown }, res: Response) => {
+    logger.info(`Transactions redirect called for path [${path}]`)
+
+    const service = req.service instanceof Service ? req.service : new Service(req.service as ServiceData)
+    const account =
+      req.account instanceof GatewayAccount ? req.account : new GatewayAccount(req.account as GatewayAccountData)
+
+    let redirectPath
+    if (req.params.chargeId) {
+      redirectPath = formatServiceAndAccountPathsFor(path, service.externalId, account.type, req.params.chargeId)
+    } else {
+      redirectPath = formatServiceAndAccountPathsFor(path, service.externalId, account.type)
+    }
+
+    logger.info(`Redirecting to ${redirectPath}`)
+    return res.redirect(redirectPath)
+  }
+}
+
+export function allServiceTransactionRedirect(path: string) {
+  if (!Features.isEnabled(Features.TRANSACTIONS)) {
+    return (req: Request, res: Response, next: NextFunction) => {
+      return next()
+    }
+  }
+
+  return (req: Request, res: Response) => {
+    logger.info(`All service transactions redirect called for path [${path}]`)
+    if (!req.params.statusFilter) {
+      return res.redirect(formatPathFor(path, 'live'))
+    }
+
+    const redirectPath = formatPathFor(path, req.params.statusFilter)
+    logger.info(`Redirecting to ${redirectPath}`)
+    return res.redirect(redirectPath)
+  }
+}
+
+export function allServiceTransactionDetailRedirect(path: string) {
+  if (!Features.isEnabled(Features.TRANSACTIONS)) {
+    return (req: Request, res: Response, next: NextFunction) => {
+      return next()
+    }
+  }
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    logger.info(`All service transactions detail redirect called for path [${path}]`)
+
+    if (!req.params.chargeId) {
+      throw new NotFoundError('Charge ID not found when attempting to redirect to all-service-transactions detail page')
+    }
+
+    let redirectPath
+    try {
+      const charge = (await Ledger.transactionWithAccountOverride(req.params.chargeId)) as TransactionData
+      if (!userServicesContainsGatewayAccount(charge.gateway_account_id, req.user)) {
+        return next(new NotFoundError('User does not have access to gateway account for transaction'))
+      }
+      const account = await getGatewayAccountById(charge.gateway_account_id as unknown as number)
+
+      redirectPath = formatServiceAndAccountPathsFor(path, account.serviceId, account.type, req.params.chargeId)
+    } catch (err) {
+      if (err === 'NOT_FOUND') {
+        return next(new NotFoundError('Transaction not found'))
+      } else {
+        return next(err)
+      }
+    }
+
+    logger.info(`Redirecting to ${redirectPath}`)
+    return res.redirect(redirectPath)
+  }
+}

--- a/src/models/gateway-account/GatewayAccount.class.ts
+++ b/src/models/gateway-account/GatewayAccount.class.ts
@@ -34,7 +34,7 @@ class GatewayAccount {
   readonly rawResponse: GatewayAccountData
   readonly sendPayerEmailToGateway: boolean
   readonly sendPayerIPAddressToGateway: boolean
-  readonly serviceId?: string
+  readonly serviceId: string
   readonly serviceName: string
 
   constructor(gatewayAccountData: GatewayAccountData) {

--- a/src/models/gateway-account/dto/GatewayAccount.dto.ts
+++ b/src/models/gateway-account/dto/GatewayAccount.dto.ts
@@ -26,5 +26,5 @@ export interface GatewayAccountData {
   worldpay_3ds_flex?: Worldpay3dsFlexCredentialData
   send_payer_email_to_gateway: boolean
   send_payer_ip_address_to_gateway: boolean
-  service_id?: string
+  service_id: string
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,6 +23,10 @@ const permission = require('./middleware/permission')
 const inviteCookieIsPresent = require('./middleware/invite-cookie-is-present')
 const validateStatusFilter = require('@middleware/validate-status-filter')
 const { validateModeFilter, viewModeStrategy } = require('@middleware/view-mode-strategy.middleware')
+const {
+  transactionRedirect,
+  allServiceTransactionRedirect,
+} = require('@middleware/simplified-account/transaction-redirect.middleware')
 
 // Controllers
 const staticController = require('./controllers/static.controller')
@@ -65,6 +69,7 @@ const formatServiceAndAccountPathsFor = require('@utils/simplified-account/forma
 import { serviceViewShim, setServiceView } from '@middleware/simplified-account/service-view-shim.middleware'
 import { Features } from '@root/config/features'
 import { ServiceView } from '@models/service-view/ServiceView.class'
+import { allServiceTransactionDetailRedirect } from '@middleware/simplified-account/transaction-redirect.middleware'
 
 // Assignments
 const {
@@ -171,27 +176,45 @@ module.exports.bind = function (app) {
   app.get(services.create.selectOrgType, userIsAuthorised, selectOrgTypeController.get)
 
   // All service transactions
-  app.get(allServiceTransactions.index, userIsAuthorised, allTransactionsController.getController)
+  app.get(
+    allServiceTransactions.index,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
+    userIsAuthorised,
+    allTransactionsController.getController
+  )
   app.get(
     allServiceTransactions.indexStatusFilter,
     validateStatusFilter,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
     userIsAuthorised,
     allTransactionsController.getController
   )
   app.get(
     allServiceTransactions.indexStatusFilterWithoutSearch,
     validateStatusFilter,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.nosearch),
     userIsAuthorised,
     allTransactionsController.noAutosearchTransactions
   )
-  app.get(allServiceTransactions.download, userIsAuthorised, allTransactionsController.downloadTransactions)
   app.get(
-    allServiceTransactions.downloadStatusFilter,
-    validateStatusFilter,
+    allServiceTransactions.download,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
     userIsAuthorised,
     allTransactionsController.downloadTransactions
   )
-  app.get(allServiceTransactions.redirectDetail, userIsAuthorised, transactionDetailRedirectController)
+  app.get(
+    allServiceTransactions.downloadStatusFilter,
+    validateStatusFilter,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
+    userIsAuthorised,
+    allTransactionsController.downloadTransactions
+  )
+  app.get(
+    allServiceTransactions.redirectDetail,
+    userIsAuthorised,
+    allServiceTransactionDetailRedirect(paths.simplifiedAccount.allServiceTransactions.detail),
+    transactionDetailRedirectController
+  )
 
   // all service transactions - simplified account
   app.get(
@@ -331,15 +354,33 @@ module.exports.bind = function (app) {
   })
 
   // Transactions
-  account.get(transactions.index, permission('transactions:read'), serviceViewShim, transactionsListController)
-  account.get(transactions.download, permission('transactions-download:read'), transactionsDownloadController)
+  account.get(
+    transactions.index,
+    permission('transactions:read'),
+    transactionRedirect(paths.simplifiedAccount.transactions.index),
+    serviceViewShim,
+    transactionsListController
+  )
+  account.get(
+    transactions.download,
+    permission('transactions-download:read'),
+    transactionRedirect(paths.simplifiedAccount.transactions.downloadCsv),
+    transactionsDownloadController
+  )
   account.get(
     transactions.detail,
     permission('transactions-details:read'),
+    transactionRedirect(paths.simplifiedAccount.transactions.detail),
     serviceViewShim,
     transactionDetailController
   )
-  account.post(transactions.refund, permission('refunds:create'), serviceViewShim, transactionRefundController)
+  account.post(
+    transactions.refund,
+    permission('refunds:create'),
+    transactionRedirect(paths.simplifiedAccount.transactions.index),
+    serviceViewShim,
+    transactionRefundController
+  )
 
   // Settings
   app.use(paths.simplifiedAccount.root, simplifiedAccountRoutes)

--- a/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
@@ -12,29 +12,29 @@ const gatewayAccountStripe = {
   gatewayAccountExternalId: 'a-valid-external-id-1',
   type: 'live',
   paymentProvider: 'stripe',
-  recurringEnabled: true
+  recurringEnabled: true,
 }
 const gatewayAccount2 = {
   gatewayAccountId: 43,
   gatewayAccountExternalId: 'a-valid-external-id-2',
   type: 'live',
-  recurringEnabled: true
+  recurringEnabled: true,
 }
 const gatewayAccount3 = {
   gatewayAccountId: 44,
   gatewayAccountExternalId: 'a-valid-external-id-3',
   type: 'test',
-  recurringEnabled: true
+  recurringEnabled: true,
 }
 const userStub = userStubs.getUserSuccessWithMultipleServices(userExternalId, [
   {
     gatewayAccountId: gatewayAccountStripe.gatewayAccountId,
-    serviceName: 'Service 1'
+    serviceName: 'Service 1',
   },
   {
     gatewayAccountIds: [gatewayAccount2.gatewayAccountId, gatewayAccount3.gatewayAccountId],
-    serviceName: 'Service 2'
-  }
+    serviceName: 'Service 2',
+  },
 ])
 
 const testTransactions = [
@@ -47,56 +47,112 @@ const testTransactions = [
     state: { finished: true, status: 'success' },
     refund_summary_status: 'available',
     refund_summary_available: 5000,
-    refund_summary_submitted: 0
+    refund_summary_submitted: 0,
   },
   {
     gateway_account_id: String(gatewayAccount3.gatewayAccountId),
     reference: 'ref4',
     transaction_id: 'transaction-id-4',
-    live: false
-  }
+    live: false,
+  },
 ]
 
 describe('All service transactions without automatic search', () => {
-  beforeEach(() => {
-    cy.setEncryptedCookies(userExternalId)
+  describe('redirect', () => {
+    it('should redirect to the new pages for /test', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.request({
+        url: '/all-service-transactions/nosearch/test',
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/transactions/test/nosearch')
+      })
+    })
+
+    it('should redirect to the new pages for /live', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.request({
+        url: '/all-service-transactions/nosearch/live',
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/transactions/live/nosearch')
+      })
+    })
   })
 
-  it('should display All Service Transactions list page with no live transactions and ability to view test transactions', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccountStripe, gatewayAccount2, gatewayAccount3]),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
-        transactions: testTransactions
-      }),
-      gatewayAccountStubs.getCardTypesSuccess()
-    ])
-
-    cy.visit(liveTransactionsUrl)
-    cy.title().should('eq', 'Transactions for all services')
-
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Live')
+  describe.skip('skipping old tests', () => {
+    beforeEach(() => {
+      cy.setEncryptedCookies(userExternalId)
     })
 
-    cy.get('.transactions-list--row').should('have.length', 0)
-    cy.get('#update-filters-after-timeout').should('have.text', 'Update the filters and select the Filter button.')
+    it('should display All Service Transactions list page with no live transactions and ability to view test transactions', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
 
-    cy.visit(liveTransactionsUrl)
-    cy.log('Switch to view test transactions')
-    cy.get('a').contains('Switch to test accounts').click()
+      cy.visit(liveTransactionsUrl)
+      cy.title().should('eq', 'Transactions for all services')
 
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Live')
+      })
+
+      cy.get('.transactions-list--row').should('have.length', 0)
+      cy.get('#update-filters-after-timeout').should('have.text', 'Update the filters and select the Filter button.')
+
+      cy.visit(liveTransactionsUrl)
+      cy.log('Switch to view test transactions')
+      cy.get('a').contains('Switch to test accounts').click()
+
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      })
+
+      cy.get('.transactions-list--row').should('have.length', 2)
+      cy.get('#charge-id-transaction-id-3').should('exist')
+      cy.get('#charge-id-transaction-id-4').should('exist')
     })
-
-    cy.get('.transactions-list--row').should('have.length', 2)
-    cy.get('#charge-id-transaction-id-3').should('exist')
-    cy.get('#charge-id-transaction-id-4').should('exist')
   })
 })

--- a/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions.cy.js
@@ -77,236 +77,342 @@ describe('All service transactions', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should display All Service Transactions list page with live transactions and ability to view test transactions', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
-        gatewayAccountStripe,
-        gatewayAccount2,
-        gatewayAccount3,
-      ]),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
-        transactions: liveTransactions,
-      }),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
-        transactions: testTransactions,
-      }),
-      gatewayAccountStubs.getCardTypesSuccess(),
-    ])
+  describe('redirect', () => {
+    it('should redirect to the new pages for /test', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount3]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+          transactions: liveTransactions,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
 
-    cy.visit(transactionsUrl)
-    cy.title().should('eq', 'Transactions for all services')
-
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Live')
+      cy.request({
+        url: '/all-service-transactions/test',
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/transactions/test')
+      })
     })
 
-    cy.get('.transactions-list--row').should('have.length', 2)
-    cy.get('#charge-id-transaction-id-1')
-      .should('exist')
-      .should('have.attr', 'href', '/redirect/transactions/transaction-id-1')
-    cy.get('#charge-id-transaction-id-2')
-      .should('exist')
-      .should('have.attr', 'href', '/redirect/transactions/transaction-id-2')
+    it('should redirect to the new pages for /live', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount3]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+          transactions: liveTransactions,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
 
-    cy.visit(transactionsUrl)
-    cy.log('Switch to view test transactions')
-    cy.get('a').contains('Switch to test accounts').click()
-
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      cy.request({
+        url: '/all-service-transactions/live',
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/transactions/live')
+      })
     })
 
-    cy.get('.transactions-list--row').should('have.length', 2)
-    cy.get('#charge-id-transaction-id-3').should('exist')
-    cy.get('#charge-id-transaction-id-4').should('exist')
+    it('should redirect to the /live new pages if no filter is provided', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount3]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+          transactions: liveTransactions,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.request({
+        url: '/all-service-transactions',
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/transactions/live')
+      })
+    })
+
+    it('should redirect to the new details page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([gatewayAccount3]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+          transactions: liveTransactions,
+        }),
+        transactionStubs.getLedgerTransactionSuccess({
+          transactionDetails: testTransactions[0],
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.request({
+        url: `/redirect/transactions/transaction-id-3`,
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq(
+          '/service/service456def/account/test/all-services/transactions/transaction-id-3'
+        )
+      })
+    })
   })
 
-  it('should have links back to all service transactions when navigating to transaction detail page', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
-        gatewayAccountStripe,
-        gatewayAccount2,
-        gatewayAccount3,
-      ]),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
-        transactions: testTransactions,
-      }),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
-        transactions: [testTransactions[0]],
-        filters: {
-          reference: 'ref3',
-        },
-      }),
-      gatewayAccountStubs.getCardTypesSuccess(),
-      transactionStubs.getLedgerTransactionSuccess({
-        transactionDetails: testTransactions[0],
-        gatewayAccountId: gatewayAccount3.gatewayAccountId,
-      }),
-      transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
-      gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
-      gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
-      transactionStubs.getLedgerEventsSuccess({
-        transactionId: 'transaction-id-3',
-        gatewayAccountId: gatewayAccount3.gatewayAccountId,
-      }),
-    ])
+  describe.skip('skipping old tests', () => {
+    it('should display All Service Transactions list page with live transactions and ability to view test transactions', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccountStripe.gatewayAccountId, gatewayAccount2.gatewayAccountId],
+          transactions: liveTransactions,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
 
-    cy.visit('/all-service-transactions/test')
-    // Add some filters, so we can check the back links will include them
-    cy.get('#reference').type('ref3')
-    cy.get('#filter').click()
-    cy.get('.transactions-list--row').should('have.length', 1)
-    cy.get('#charge-id-transaction-id-3').should('exist')
+      cy.visit(transactionsUrl)
+      cy.title().should('eq', 'Transactions for all services')
 
-    cy.get('#charge-id-transaction-id-3').click()
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Live')
+      })
 
-    cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('contain', 'Service 2')
-    cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('contain', 'ref3')
+      cy.get('.transactions-list--row').should('have.length', 2)
+      cy.get('#charge-id-transaction-id-1')
+        .should('exist')
+        .should('have.attr', 'href', '/redirect/transactions/transaction-id-1')
+      cy.get('#charge-id-transaction-id-2')
+        .should('exist')
+        .should('have.attr', 'href', '/redirect/transactions/transaction-id-2')
 
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      cy.visit(transactionsUrl)
+      cy.log('Switch to view test transactions')
+      cy.get('a').contains('Switch to test accounts').click()
+
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      })
+
+      cy.get('.transactions-list--row').should('have.length', 2)
+      cy.get('#charge-id-transaction-id-3').should('exist')
+      cy.get('#charge-id-transaction-id-4').should('exist')
     })
 
-    cy.get('.govuk-back-link')
-      .should('have.text', 'Back to transactions for all services')
-      .should(
-        'have.attr',
-        'href',
-        '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId='
+    it('should have links back to all service transactions when navigating to transaction detail page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: testTransactions,
+        }),
+        transactionStubs.getLedgerTransactionsSuccess({
+          gatewayAccountIds: [gatewayAccount3.gatewayAccountId],
+          transactions: [testTransactions[0]],
+          filters: {
+            reference: 'ref3',
+          },
+        }),
+        gatewayAccountStubs.getCardTypesSuccess(),
+        transactionStubs.getLedgerTransactionSuccess({
+          transactionDetails: testTransactions[0],
+          gatewayAccountId: gatewayAccount3.gatewayAccountId,
+        }),
+        transactionStubs.getLedgerTransactionSuccess({ transactionDetails: testTransactions[0] }),
+        gatewayAccountStubs.getGatewayAccountSuccess(gatewayAccount3),
+        gatewayAccountStubs.getGatewayAccountByExternalIdSuccess(gatewayAccount3),
+        transactionStubs.getLedgerEventsSuccess({
+          transactionId: 'transaction-id-3',
+          gatewayAccountId: gatewayAccount3.gatewayAccountId,
+        }),
+      ])
+
+      cy.visit('/all-service-transactions/test')
+      // Add some filters, so we can check the back links will include them
+      cy.get('#reference').type('ref3')
+      cy.get('#filter').click()
+      cy.get('.transactions-list--row').should('have.length', 1)
+      cy.get('#charge-id-transaction-id-3').should('exist')
+
+      cy.get('#charge-id-transaction-id-3').click()
+
+      cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('contain', 'Service 2')
+      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('contain', 'ref3')
+
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      })
+
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back to transactions for all services')
+        .should(
+          'have.attr',
+          'href',
+          '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId='
+        )
+
+      cy.get('a.refund__toggle').click()
+      cy.get('button').contains('Confirm refund').click()
+
+      cy.get('.govuk-breadcrumbs').within(() => {
+        cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
+        cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      })
+
+      cy.get('.govuk-back-link')
+        .should('have.text', 'Back to transactions for all services')
+        .should(
+          'have.attr',
+          'href',
+          '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId='
+        )
+    })
+
+    it('should redirect from /all-services-transactions/live to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+
+        transactionStubs.getLedgerTransactionsFailure(
+          {
+            account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
+            page: 1,
+            display_size: 100,
+            limit_total: true,
+            limit_total_size: 5001,
+          },
+          504
+        ),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.visit('/all-service-transactions/live', { failOnStatusCode: false })
+
+      cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
+      cy.get('#errorMsg').should(
+        'have.text',
+        'The search has timed out. Try searching for a specific date range or applying other filters.'
       )
 
-    cy.get('a.refund__toggle').click()
-    cy.get('button').contains('Confirm refund').click()
+      cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
 
-    cy.get('.govuk-breadcrumbs').within(() => {
-      cy.get('.govuk-breadcrumbs__list-item').should('have.length', 2)
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Transactions for all services')
-      cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Test')
+      cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
     })
 
-    cy.get('.govuk-back-link')
-      .should('have.text', 'Back to transactions for all services')
-      .should(
-        'have.attr',
-        'href',
-        '/all-service-transactions/test?reference=ref3&email=&cardholderName=&lastDigitsCardNumber=&fromDate=&fromTime=&toDate=&toTime=&metadataValue=&agreementId='
+    it('should redirect from /all-services-transactions/test to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
+
+        transactionStubs.getLedgerTransactionsFailure(
+          {
+            account_id: `${gatewayAccount3.gatewayAccountId}`,
+            page: 1,
+            display_size: 100,
+            limit_total: true,
+            limit_total_size: 5001,
+          },
+          504
+        ),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
+
+      cy.visit('/all-service-transactions/test', { failOnStatusCode: false })
+
+      cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
+      cy.get('#errorMsg').should(
+        'have.text',
+        'The search has timed out. Try searching for a specific date range or applying other filters.'
       )
-  })
 
-  it('should redirect from /all-services-transactions/live to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
-        gatewayAccountStripe,
-        gatewayAccount2,
-        gatewayAccount3,
-      ]),
+      cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
 
-      transactionStubs.getLedgerTransactionsFailure(
-        {
-          account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
-          page: 1,
-          display_size: 100,
-          limit_total: true,
-          limit_total_size: 5001,
-        },
-        504
-      ),
-      gatewayAccountStubs.getCardTypesSuccess(),
-    ])
+      cy.location('pathname').should('eq', '/all-service-transactions/nosearch/test')
+    })
 
-    cy.visit('/all-service-transactions/live', { failOnStatusCode: false })
+    it('should redirect from /all-services-transactions to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
+      cy.task('setupStubs', [
+        userStub,
+        gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
+          gatewayAccountStripe,
+          gatewayAccount2,
+          gatewayAccount3,
+        ]),
 
-    cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
-    cy.get('#errorMsg').should(
-      'have.text',
-      'The search has timed out. Try searching for a specific date range or applying other filters.'
-    )
+        transactionStubs.getLedgerTransactionsFailure(
+          {
+            account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
+            page: 1,
+            display_size: 100,
+            limit_total: true,
+            limit_total_size: 5001,
+          },
+          504
+        ),
+        gatewayAccountStubs.getCardTypesSuccess(),
+      ])
 
-    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
+      cy.visit('/all-service-transactions', { failOnStatusCode: false })
 
-    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
-  })
+      cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
+      cy.get('#errorMsg').should(
+        'have.text',
+        'The search has timed out. Try searching for a specific date range or applying other filters.'
+      )
 
-  it('should redirect from /all-services-transactions/test to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
-        gatewayAccountStripe,
-        gatewayAccount2,
-        gatewayAccount3,
-      ]),
+      cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
 
-      transactionStubs.getLedgerTransactionsFailure(
-        {
-          account_id: `${gatewayAccount3.gatewayAccountId}`,
-          page: 1,
-          display_size: 100,
-          limit_total: true,
-          limit_total_size: 5001,
-        },
-        504
-      ),
-      gatewayAccountStubs.getCardTypesSuccess(),
-    ])
-
-    cy.visit('/all-service-transactions/test', { failOnStatusCode: false })
-
-    cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
-    cy.get('#errorMsg').should(
-      'have.text',
-      'The search has timed out. Try searching for a specific date range or applying other filters.'
-    )
-
-    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
-
-    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/test')
-  })
-
-  it('should redirect from /all-services-transactions to failure page when ledger returns 504 and allow user to navigate to no autosearch transactions page', () => {
-    cy.task('setupStubs', [
-      userStub,
-      gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
-        gatewayAccountStripe,
-        gatewayAccount2,
-        gatewayAccount3,
-      ]),
-
-      transactionStubs.getLedgerTransactionsFailure(
-        {
-          account_id: `${gatewayAccountStripe.gatewayAccountId},${gatewayAccount2.gatewayAccountId}`,
-          page: 1,
-          display_size: 100,
-          limit_total: true,
-          limit_total_size: 5001,
-        },
-        504
-      ),
-      gatewayAccountStubs.getCardTypesSuccess(),
-    ])
-
-    cy.visit('/all-service-transactions', { failOnStatusCode: false })
-
-    cy.get('.govuk-heading-l').should('have.text', 'An error occurred')
-    cy.get('#errorMsg').should(
-      'have.text',
-      'The search has timed out. Try searching for a specific date range or applying other filters.'
-    )
-
-    cy.get('.govuk-body').get('a').contains('Back to transactions search').click()
-
-    cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
+      cy.location('pathname').should('eq', '/all-service-transactions/nosearch/live')
+    })
   })
 })

--- a/test/cypress/integration/transactions/transaction-details.cy.js
+++ b/test/cypress/integration/transactions/transaction-details.cy.js
@@ -126,13 +126,12 @@ describe('Transaction details page', () => {
     }
     return stubs
   }
-
   beforeEach(() => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('page content', () => {
-    it('should display transaction details correctly with optional data', function () {
+  describe('redirect', () => {
+    it('should redirect to the new transaction details page', () => {
       const transactionDetails = defaultTransactionDetails()
       transactionDetails.wallet_type = 'APPLE_PAY'
       transactionDetails.metadata = {
@@ -170,631 +169,701 @@ describe('Transaction details page', () => {
       }
 
       cy.task('setupStubs', getStubs(transactionDetails, gatewayAccountOptions))
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Reference number
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .first()
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.reference)
-      // Status
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .first()
-        .should('contain', capitalise(transactionDetails.state.status))
-      // Amount
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(3)
-        .find('td')
-        .first()
-        .should(
-          'have.text',
-          `${convertPenceToPoundsFormatted(transactionDetails.total_amount)} (including a card fee of ${convertPenceToPoundsFormatted(transactionDetails.corporate_card_surcharge)})`
+      cy.request({
+        url: `${transactionsUrl}/${transactionDetails.transaction_id}`,
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq(
+          `/service/cp5wa/account/test/transactions/${transactionDetails.transaction_id}`
         )
-      // PSP Fee
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(4)
-        .find('td')
-        .first()
-        .should('have.text', convertPenceToPoundsFormatted(transactionDetails.fee))
-      // Net amount
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(5)
-        .find('td')
-        .first()
-        .should('have.text', convertPenceToPoundsFormatted(transactionDetails.net_amount))
-      // Refund submitted
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(6)
-        .find('td')
-        .first()
-        .should('have.text', convertPenceToPoundsFormatted(transactionDetails.refund_summary_submitted))
-      // Date created
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(7)
-        .find('td')
-        .first()
-        .should('contain', formatDate(new Date(transactionDetails.events[0].timestamp)))
-      // 3D Secure
-      cy.get('.transaction-details tbody').find('tr').eq(8).find('td').first().should('have.text', 'Required')
-      // Corporate exemption requested
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(9)
-        .find('td')
-        .first()
-        .should('have.text', capitalise(transactionDetails.exemption.outcome.result))
-      // Provider
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(10)
-        .find('td')
-        .first()
-        .should('have.text', capitalise(transactionDetails.payment_provider))
-      // Provider ID
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(11)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.gateway_transaction_id)
-      // GOVUK Payment ID
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(12)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.transaction_id)
-      // Delayed capture
-      cy.get('.transaction-details tbody').find('tr').eq(13).find('td').first().should('have.text', 'On')
-      // Moto
-      cy.get('.transaction-details tbody').find('tr').eq(14).find('td').first().should('have.text', 'Yes')
-      // Payment method
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(15)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.card_brand)
-      // Name on card
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(16)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.cardholder_name)
-      // Card number
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(17)
-        .find('td')
-        .first()
-        .should('have.text', `**** **** **** ${transactionDetails.last_digits_card_number}`)
-      // Card expiry date
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(18)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.expiry_date)
-      // Wallett type
-      cy.get('.transaction-details tbody').find('tr').eq(19).find('td').first().should('have.text', 'Apple Pay')
-      // Email
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(20)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.email)
-      // Metadata
-      cy.get('h2').should('contain', 'Metadata')
-      cy.get('th').contains('key1').siblings().first().should('contain', '123')
-      cy.get('th').contains('key2').siblings().first().should('contain', 'true')
-      cy.get('th').contains('key3').siblings().first().should('contain', 'some string')
-    })
-
-    it('should display transaction details and a list of history with no optional data', () => {
-      const events = [
-        {
-          event_type: 'PAYMENT_CREATED',
-          status: 'created',
-          finished: false,
-          amount: '1000',
-          timestamp: '2018-12-24 13:21:05',
-        },
-        {
-          event_type: 'PAYMENT_STARTED',
-          status: 'started',
-          finished: false,
-          amount: '1000',
-          timestamp: '2018-12-24 13:23:12',
-        },
-        {
-          event_type: 'AUTHORISATION_SUCCEEDED',
-          status: 'submitted',
-          finished: false,
-          amount: '1000',
-          timestamp: '2018-12-24 12:05:43',
-        },
-        {
-          event_type: 'USER_APPROVED_FOR_CAPTURE',
-          status: 'success',
-          finished: true,
-          amount: '1000',
-          timestamp: '2018-12-24 12:05:43',
-        },
-      ]
-      const opts = {
-        includeAddress: false,
-      }
-
-      const transactionDetails = defaultTransactionDetails(events, opts)
-      cy.task('setupStubs', getStubs(transactionDetails))
-
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Ensure page details match up
-      // Reference number
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .first()
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.reference)
-      // Status
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .first()
-        .should('contain', capitalise(transactionDetails.state.status))
-      // Amount
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(3)
-        .find('td')
-        .first()
-        .should('have.text', convertPenceToPoundsFormatted(transactionDetails.amount))
-      // Refunded amount
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(4)
-        .find('td')
-        .first()
-        .should('have.text', convertPenceToPoundsFormatted(transactionDetails.refund_summary_submitted))
-      // Date created
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(5)
-        .find('td')
-        .first()
-        .should('contain', formatDate(new Date(transactionDetails.events[0].timestamp)))
-      // Provider
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(6)
-        .find('td')
-        .first()
-        .should('have.text', capitalise(transactionDetails.payment_provider))
-      // Provider ID
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(7)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.gateway_transaction_id)
-      // GOVUK Payment ID
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(8)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.transaction_id)
-      // Payment method
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(9)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.card_brand)
-      // Name on card
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(10)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.cardholder_name)
-      // // Card number
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(11)
-        .find('td')
-        .first()
-        .should('have.text', `**** **** **** ${transactionDetails.last_digits_card_number}`)
-      // Card expiry date
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(12)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.expiry_date)
-      // Email
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(13)
-        .find('td')
-        .first()
-        .should('have.text', transactionDetails.email)
-      cy.get('#delayed-capture').should('not.exist')
-      cy.get('.transaction-details tbody').should('not.contain', 'Wallet Type')
-      cy.get('h2').should('not.contain', 'Metadata')
-      cy.get('th').contains('MOTO:').should('not.exist')
-
-      // History details
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(0)
-        .find('td')
-        .eq(0)
-        .should('contain', capitalise(events[3].status))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(0)
-        .find('td')
-        .eq(1)
-        .should('contain', convertPenceToPoundsFormatted(events[3].amount))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(0)
-        .find('td')
-        .eq(2)
-        .should('contain', formatDate(new Date(events[3].timestamp)))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(1)
-        .find('td')
-        .eq(0)
-        .should('contain', capitalise(events[2].status))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(1)
-        .find('td')
-        .eq(1)
-        .should('contain', convertPenceToPoundsFormatted(events[2].amount))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(1)
-        .find('td')
-        .eq(2)
-        .should('contain', formatDate(new Date(events[2].timestamp)))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .eq(0)
-        .should('contain', capitalise(events[1].status))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .eq(1)
-        .should('contain', convertPenceToPoundsFormatted(events[1].amount))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .eq(2)
-        .should('contain', formatDate(new Date(events[1].timestamp)))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(3)
-        .find('td')
-        .eq(0)
-        .should('contain', capitalise(events[0].status))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(3)
-        .find('td')
-        .eq(1)
-        .should('contain', convertPenceToPoundsFormatted(events[0].amount))
-      cy.get('.transaction-events tbody')
-        .find('tr')
-        .eq(3)
-        .find('td')
-        .eq(2)
-        .should('contain', formatDate(new Date(events[0].timestamp)))
-    })
-
-    it("should display 'Data unavailable' for redact fields and hide transaction events section when there are no events", () => {
-      const events = []
-      const opts = {
-        includeAddress: false,
-        reference: '<DELETED>',
-        description: '<DELETED>',
-        email: '<DELETED>',
-        cardholder_name: '<DELETED>',
-      }
-
-      const transactionDetails = defaultTransactionDetails(events, opts)
-      cy.task('setupStubs', getStubs(transactionDetails))
-
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Reference number
-      cy.get('.transaction-details tbody').find('tr').first().find('td').first().should('have.text', 'Data unavailable')
-      // description
-      cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('have.text', 'Data unavailable')
-      // Name on card
-      cy.get('.transaction-details tbody').find('tr').eq(10).find('td').first().should('have.text', 'Data unavailable')
-      // Email
-      cy.get('.transaction-details tbody').find('tr').eq(13).find('td').first().should('have.text', 'Data unavailable')
-
-      // transaction events
-      cy.get('.transaction-events').should('not.exist')
+      })
     })
   })
 
-  describe('refunds', () => {
-    it('should show success message when full refund is successful', () => {
-      const transactionDetails = defaultTransactionDetails()
-      const refundAmount = transactionDetails.amount
-      const stubs = [
-        ...getStubs(transactionDetails),
-        transactionStubs.postRefundSuccess({
-          gatewayAccountId,
-          userExternalId,
-          userEmail,
-          transactionId: transactionDetails.transaction_id,
-          refundAmount,
-          refundAmountAvailable: transactionDetails.amount,
-        }),
-      ]
-      cy.task('setupStubs', stubs)
+  describe.skip('skipping old tests', () => {
+    describe('page content', () => {
+      it('should display transaction details correctly with optional data', function () {
+        const transactionDetails = defaultTransactionDetails()
+        transactionDetails.wallet_type = 'APPLE_PAY'
+        transactionDetails.metadata = {
+          key1: 123,
+          key2: true,
+          key3: 'some string',
+        }
+        transactionDetails.payment_provider = 'stripe'
+        transactionDetails.fee = 100
+        transactionDetails.net_amount = defaultAmount - 100
+        transactionDetails.moto = true
+        transactionDetails.delayed_capture = true
+        transactionDetails.corporate_card_surcharge = 250
+        transactionDetails.total_amount = 1250
 
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      cy.get('#refundForm').should('exist')
-
-      // Click the refund button
-      cy.get('.target-to-show--toggle').click()
-
-      cy.get('.govuk-radios__input#full').should('be.checked')
-
-      // Click the refund submit button
-      cy.get('#refund-button').click()
-
-      // Ensure the flash container is showing
-      cy.get('.govuk-notification-banner--success').should('be.visible')
-
-      cy.get('.govuk-notification-banner__heading').should('contain', 'Refund successful')
-    })
-
-    it('should fail when an invalid refund amount is specified', () => {
-      const transactionDetails = defaultTransactionDetails()
-      const refundAmount = transactionDetails.amount + 1
-      const stubs = [
-        ...getStubs(transactionDetails),
-        transactionStubs.postRefundAmountNotAvailable({
-          gatewayAccountId,
-          userExternalId,
-          userEmail,
-          transactionId: transactionDetails.transaction_id,
-          refundAmount,
-          refundAmountAvailable: transactionDetails.amount,
-        }),
-      ]
-      cy.task('setupStubs', stubs)
-
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Click the refund button
-      cy.get('.target-to-show--toggle').click()
-
-      // Select partial refund
-      cy.get('.govuk-radios__input#partial').click()
-      cy.get('.govuk-radios__input#full').should('not.be.checked')
-      cy.get('.govuk-radios__input#partial').should('be.checked')
-
-      // Select partial refund
-      cy.get('#refund-amount').type('10.01')
-
-      // Click the refund submit button
-      cy.get('#refund-button').click()
-
-      // Ensure the flash container is showing
-      cy.get('.govuk-error-summary').should('be.visible')
-
-      cy.get('.govuk-error-summary').find('h2').should('contain', 'Refund failed')
-      cy.get('.govuk-error-summary')
-        .find('ul.govuk-error-summary__list > li:nth-child(1)')
-        .should(
-          'contain',
-          'The amount you tried to refund is greater than the amount available to be refunded. Please try again.'
-        )
-    })
-
-    it('should allow a refund to be re-attempted in the event of a failed refund', () => {
-      const aFailedRefundTransaction = defaultTransactionDetails()
-      aFailedRefundTransaction.refund_summary_status = 'error'
-      cy.task('setupStubs', getStubs(aFailedRefundTransaction))
-
-      cy.visit(`${transactionsUrl}/${aFailedRefundTransaction.transaction_id}`)
-
-      // Ensure the refund button is available
-      cy.get('.target-to-show--toggle').should('be.visible')
-
-      // Click the refund button
-      cy.get('.target-to-show--toggle').click()
-
-      // Select partial refund
-      cy.get('#partial').click()
-
-      // Select partial refund
-      cy.get('#refund-amount').type(aFailedRefundTransaction.amount / 100)
-
-      // Click the refund submit button
-      cy.get('#refund-button').click()
-    })
-
-    it('should display full refund amount with corporate card surcharge when there is a corporate card surcharge', () => {
-      const aCorporateCardSurchargeTransaction = defaultTransactionDetails()
-      aCorporateCardSurchargeTransaction.corporate_card_surcharge = 250
-      aCorporateCardSurchargeTransaction.total_amount = 1250
-      cy.task('setupStubs', getStubs(aCorporateCardSurchargeTransaction))
-
-      cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeTransaction.transaction_id}`)
-
-      // Click the refund button
-      cy.get('.target-to-show--toggle').click()
-
-      // Assert refund message
-      cy.get('.govuk-radios__hint')
-        .first()
-        .should(
-          'contain',
-          `Refund the full amount of ${convertPenceToPoundsFormatted(aCorporateCardSurchargeTransaction.refund_summary_available)} (including a card fee of ${convertPenceToPoundsFormatted(aCorporateCardSurchargeTransaction.corporate_card_surcharge)})`
-        )
-    })
-
-    it('should display full refund amount without corporate card surcharge when there is no corporate card surcharge', () => {
-      const transactionDetails = defaultTransactionDetails()
-      cy.task('setupStubs', getStubs(transactionDetails))
-      cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
-
-      // Click the refund button
-      cy.get('.target-to-show--toggle').click()
-
-      // Assert refund message
-      cy.get('.govuk-radios__hint')
-        .first()
-        .should(
-          'contain',
-          `Refund the full amount of ${convertPenceToPoundsFormatted(transactionDetails.refund_summary_available)}`
-        )
-    })
-  })
-
-  describe('Disputed payment', () => {
-    it('should display won dispute with positive amount in transaction details', () => {
-      const disputedPaymentDetails = defaultTransactionDetails()
-      disputedPaymentDetails.disputed = true
-
-      disputedPaymentDetails.events = [
-        {
-          type: 'PAYMENT',
-          status: 'success',
-          finished: true,
-          amount: defaultAmount,
-          timestamp: '2022-07-20T14:45:22.000Z',
-        },
-        {
-          type: 'DISPUTE',
-          status: 'won',
-          finished: true,
-          amount: defaultAmount,
-          timestamp: '2022-07-29T16:30:45.000Z',
-        },
-      ]
-
-      const wonDisputeDetails = {
-        parent_transaction_id: transactionId,
-        gateway_account_id: gatewayAccountId,
-        transactions: [
-          {
-            gateway_account_id: gatewayAccountId,
-            amount: 20000,
-            fee: 1500,
-            net_amount: 20000,
-            finished: true,
-            status: 'won',
-            created_date: '2022-07-26T19:57:26.000Z',
-            type: 'dispute',
-            includePaymentDetails: true,
-            evidence_due_date: '2022-08-04T13:59:59.000Z',
-            reason: 'product_not_received',
-            transaction_id: disputeTransactionId,
-            parent_transaction_id: transactionId,
+        transactionDetails.authorisation_summary = {
+          three_d_secure: {
+            required: true,
           },
-        ],
-      }
+        }
 
-      cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, wonDisputeDetails))
-      cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+        transactionDetails.exemption = {
+          requested: true,
+          type: 'corporate',
+          outcome: {
+            result: 'honoured',
+          },
+        }
 
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .first()
-        .should('contain', 'Dispute won in your favour')
+        const gatewayAccountOptions = {
+          allow_moto: true,
+          worldpay_3ds_flex: {
+            corporate_exemptions_enabled: true,
+          },
+        }
 
-      cy.get('.transaction-events tbody tr')
-        .contains(formatDate(new Date(disputedPaymentDetails.events[1].timestamp)))
-        .closest('tr')
-        .find('td')
-        .eq(1)
-        .should('contain', '£10.00')
-        .should('not.contain', '–£10.00')
+        cy.task('setupStubs', getStubs(transactionDetails, gatewayAccountOptions))
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
-      cy.get('[data-cy=dispute-details]').contains('Dispute details').should('exist')
-      cy.get('[data-cy=dispute-details-container]').within(() => {
-        cy.get('[data-cy=dispute-state]').contains('Dispute won in your favour').should('exist')
-        cy.get('[data-cy=dispute-amount]').contains('£200.00').should('exist')
-        cy.get('[data-cy=dispute-net-amount]').contains('£200.00').should('exist')
+        // Reference number
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .first()
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.reference)
+        // Status
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .first()
+          .should('contain', capitalise(transactionDetails.state.status))
+        // Amount
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .first()
+          .should(
+            'have.text',
+            `${convertPenceToPoundsFormatted(transactionDetails.total_amount)} (including a card fee of ${convertPenceToPoundsFormatted(transactionDetails.corporate_card_surcharge)})`
+          )
+        // PSP Fee
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(4)
+          .find('td')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionDetails.fee))
+        // Net amount
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(5)
+          .find('td')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionDetails.net_amount))
+        // Refund submitted
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(6)
+          .find('td')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionDetails.refund_summary_submitted))
+        // Date created
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(7)
+          .find('td')
+          .first()
+          .should('contain', formatDate(new Date(transactionDetails.events[0].timestamp)))
+        // 3D Secure
+        cy.get('.transaction-details tbody').find('tr').eq(8).find('td').first().should('have.text', 'Required')
+        // Corporate exemption requested
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(9)
+          .find('td')
+          .first()
+          .should('have.text', capitalise(transactionDetails.exemption.outcome.result))
+        // Provider
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(10)
+          .find('td')
+          .first()
+          .should('have.text', capitalise(transactionDetails.payment_provider))
+        // Provider ID
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(11)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.gateway_transaction_id)
+        // GOVUK Payment ID
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(12)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.transaction_id)
+        // Delayed capture
+        cy.get('.transaction-details tbody').find('tr').eq(13).find('td').first().should('have.text', 'On')
+        // Moto
+        cy.get('.transaction-details tbody').find('tr').eq(14).find('td').first().should('have.text', 'Yes')
+        // Payment method
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(15)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.card_brand)
+        // Name on card
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(16)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.cardholder_name)
+        // Card number
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(17)
+          .find('td')
+          .first()
+          .should('have.text', `**** **** **** ${transactionDetails.last_digits_card_number}`)
+        // Card expiry date
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(18)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.expiry_date)
+        // Wallett type
+        cy.get('.transaction-details tbody').find('tr').eq(19).find('td').first().should('have.text', 'Apple Pay')
+        // Email
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(20)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.email)
+        // Metadata
+        cy.get('h2').should('contain', 'Metadata')
+        cy.get('th').contains('key1').siblings().first().should('contain', '123')
+        cy.get('th').contains('key2').siblings().first().should('contain', 'true')
+        cy.get('th').contains('key3').siblings().first().should('contain', 'some string')
+      })
+
+      it('should display transaction details and a list of history with no optional data', () => {
+        const events = [
+          {
+            event_type: 'PAYMENT_CREATED',
+            status: 'created',
+            finished: false,
+            amount: '1000',
+            timestamp: '2018-12-24 13:21:05',
+          },
+          {
+            event_type: 'PAYMENT_STARTED',
+            status: 'started',
+            finished: false,
+            amount: '1000',
+            timestamp: '2018-12-24 13:23:12',
+          },
+          {
+            event_type: 'AUTHORISATION_SUCCEEDED',
+            status: 'submitted',
+            finished: false,
+            amount: '1000',
+            timestamp: '2018-12-24 12:05:43',
+          },
+          {
+            event_type: 'USER_APPROVED_FOR_CAPTURE',
+            status: 'success',
+            finished: true,
+            amount: '1000',
+            timestamp: '2018-12-24 12:05:43',
+          },
+        ]
+        const opts = {
+          includeAddress: false,
+        }
+
+        const transactionDetails = defaultTransactionDetails(events, opts)
+        cy.task('setupStubs', getStubs(transactionDetails))
+
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
+
+        // Ensure page details match up
+        // Reference number
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .first()
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.reference)
+        // Status
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .first()
+          .should('contain', capitalise(transactionDetails.state.status))
+        // Amount
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionDetails.amount))
+        // Refunded amount
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(4)
+          .find('td')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionDetails.refund_summary_submitted))
+        // Date created
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(5)
+          .find('td')
+          .first()
+          .should('contain', formatDate(new Date(transactionDetails.events[0].timestamp)))
+        // Provider
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(6)
+          .find('td')
+          .first()
+          .should('have.text', capitalise(transactionDetails.payment_provider))
+        // Provider ID
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(7)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.gateway_transaction_id)
+        // GOVUK Payment ID
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(8)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.transaction_id)
+        // Payment method
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(9)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.card_brand)
+        // Name on card
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(10)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.cardholder_name)
+        // // Card number
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(11)
+          .find('td')
+          .first()
+          .should('have.text', `**** **** **** ${transactionDetails.last_digits_card_number}`)
+        // Card expiry date
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(12)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.expiry_date)
+        // Email
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(13)
+          .find('td')
+          .first()
+          .should('have.text', transactionDetails.email)
+        cy.get('#delayed-capture').should('not.exist')
+        cy.get('.transaction-details tbody').should('not.contain', 'Wallet Type')
+        cy.get('h2').should('not.contain', 'Metadata')
+        cy.get('th').contains('MOTO:').should('not.exist')
+
+        // History details
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(0)
+          .find('td')
+          .eq(0)
+          .should('contain', capitalise(events[3].status))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(0)
+          .find('td')
+          .eq(1)
+          .should('contain', convertPenceToPoundsFormatted(events[3].amount))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(0)
+          .find('td')
+          .eq(2)
+          .should('contain', formatDate(new Date(events[3].timestamp)))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(1)
+          .find('td')
+          .eq(0)
+          .should('contain', capitalise(events[2].status))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(1)
+          .find('td')
+          .eq(1)
+          .should('contain', convertPenceToPoundsFormatted(events[2].amount))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(1)
+          .find('td')
+          .eq(2)
+          .should('contain', formatDate(new Date(events[2].timestamp)))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .eq(0)
+          .should('contain', capitalise(events[1].status))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .eq(1)
+          .should('contain', convertPenceToPoundsFormatted(events[1].amount))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .eq(2)
+          .should('contain', formatDate(new Date(events[1].timestamp)))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .eq(0)
+          .should('contain', capitalise(events[0].status))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .eq(1)
+          .should('contain', convertPenceToPoundsFormatted(events[0].amount))
+        cy.get('.transaction-events tbody')
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .eq(2)
+          .should('contain', formatDate(new Date(events[0].timestamp)))
+      })
+
+      it("should display 'Data unavailable' for redact fields and hide transaction events section when there are no events", () => {
+        const events = []
+        const opts = {
+          includeAddress: false,
+          reference: '<DELETED>',
+          description: '<DELETED>',
+          email: '<DELETED>',
+          cardholder_name: '<DELETED>',
+        }
+
+        const transactionDetails = defaultTransactionDetails(events, opts)
+        cy.task('setupStubs', getStubs(transactionDetails))
+
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
+
+        // Reference number
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .first()
+          .find('td')
+          .first()
+          .should('have.text', 'Data unavailable')
+        // description
+        cy.get('.transaction-details tbody').find('tr').eq(1).find('td').first().should('have.text', 'Data unavailable')
+        // Name on card
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(10)
+          .find('td')
+          .first()
+          .should('have.text', 'Data unavailable')
+        // Email
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(13)
+          .find('td')
+          .first()
+          .should('have.text', 'Data unavailable')
+
+        // transaction events
+        cy.get('.transaction-events').should('not.exist')
       })
     })
 
-    it('should show refund unavailable message', () => {
-      const disputedPaymentDetails = defaultTransactionDetails()
-      disputedPaymentDetails.disputed = true
-      disputedPaymentDetails.refund_summary_status = 'unavailable'
-      const disputeTransactionDetails = defaultDisputeDetails()
+    describe('refunds', () => {
+      it('should show success message when full refund is successful', () => {
+        const transactionDetails = defaultTransactionDetails()
+        const refundAmount = transactionDetails.amount
+        const stubs = [
+          ...getStubs(transactionDetails),
+          transactionStubs.postRefundSuccess({
+            gatewayAccountId,
+            userExternalId,
+            userEmail,
+            transactionId: transactionDetails.transaction_id,
+            refundAmount,
+            refundAmountAvailable: transactionDetails.amount,
+          }),
+        ]
+        cy.task('setupStubs', stubs)
 
-      cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
-      cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
 
-      cy.get('[data-cy=refund-container]').within(() => {
-        cy.get('h2').contains('Refund').should('exist')
-        cy.get('#refundForm').should('not.exist')
+        cy.get('#refundForm').should('exist')
 
-        cy.get('p').contains('You cannot refund this payment because it is being disputed.')
+        // Click the refund button
+        cy.get('.target-to-show--toggle').click()
+
+        cy.get('.govuk-radios__input#full').should('be.checked')
+
+        // Click the refund submit button
+        cy.get('#refund-button').click()
+
+        // Ensure the flash container is showing
+        cy.get('.govuk-notification-banner--success').should('be.visible')
+
+        cy.get('.govuk-notification-banner__heading').should('contain', 'Refund successful')
+      })
+
+      it('should fail when an invalid refund amount is specified', () => {
+        const transactionDetails = defaultTransactionDetails()
+        const refundAmount = transactionDetails.amount + 1
+        const stubs = [
+          ...getStubs(transactionDetails),
+          transactionStubs.postRefundAmountNotAvailable({
+            gatewayAccountId,
+            userExternalId,
+            userEmail,
+            transactionId: transactionDetails.transaction_id,
+            refundAmount,
+            refundAmountAvailable: transactionDetails.amount,
+          }),
+        ]
+        cy.task('setupStubs', stubs)
+
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
+
+        // Click the refund button
+        cy.get('.target-to-show--toggle').click()
+
+        // Select partial refund
+        cy.get('.govuk-radios__input#partial').click()
+        cy.get('.govuk-radios__input#full').should('not.be.checked')
+        cy.get('.govuk-radios__input#partial').should('be.checked')
+
+        // Select partial refund
+        cy.get('#refund-amount').type('10.01')
+
+        // Click the refund submit button
+        cy.get('#refund-button').click()
+
+        // Ensure the flash container is showing
+        cy.get('.govuk-error-summary').should('be.visible')
+
+        cy.get('.govuk-error-summary').find('h2').should('contain', 'Refund failed')
+        cy.get('.govuk-error-summary')
+          .find('ul.govuk-error-summary__list > li:nth-child(1)')
+          .should(
+            'contain',
+            'The amount you tried to refund is greater than the amount available to be refunded. Please try again.'
+          )
+      })
+
+      it('should allow a refund to be re-attempted in the event of a failed refund', () => {
+        const aFailedRefundTransaction = defaultTransactionDetails()
+        aFailedRefundTransaction.refund_summary_status = 'error'
+        cy.task('setupStubs', getStubs(aFailedRefundTransaction))
+
+        cy.visit(`${transactionsUrl}/${aFailedRefundTransaction.transaction_id}`)
+
+        // Ensure the refund button is available
+        cy.get('.target-to-show--toggle').should('be.visible')
+
+        // Click the refund button
+        cy.get('.target-to-show--toggle').click()
+
+        // Select partial refund
+        cy.get('#partial').click()
+
+        // Select partial refund
+        cy.get('#refund-amount').type(aFailedRefundTransaction.amount / 100)
+
+        // Click the refund submit button
+        cy.get('#refund-button').click()
+      })
+
+      it('should display full refund amount with corporate card surcharge when there is a corporate card surcharge', () => {
+        const aCorporateCardSurchargeTransaction = defaultTransactionDetails()
+        aCorporateCardSurchargeTransaction.corporate_card_surcharge = 250
+        aCorporateCardSurchargeTransaction.total_amount = 1250
+        cy.task('setupStubs', getStubs(aCorporateCardSurchargeTransaction))
+
+        cy.visit(`${transactionsUrl}/${aCorporateCardSurchargeTransaction.transaction_id}`)
+
+        // Click the refund button
+        cy.get('.target-to-show--toggle').click()
+
+        // Assert refund message
+        cy.get('.govuk-radios__hint')
+          .first()
+          .should(
+            'contain',
+            `Refund the full amount of ${convertPenceToPoundsFormatted(aCorporateCardSurchargeTransaction.refund_summary_available)} (including a card fee of ${convertPenceToPoundsFormatted(aCorporateCardSurchargeTransaction.corporate_card_surcharge)})`
+          )
+      })
+
+      it('should display full refund amount without corporate card surcharge when there is no corporate card surcharge', () => {
+        const transactionDetails = defaultTransactionDetails()
+        cy.task('setupStubs', getStubs(transactionDetails))
+        cy.visit(`${transactionsUrl}/${transactionDetails.transaction_id}`)
+
+        // Click the refund button
+        cy.get('.target-to-show--toggle').click()
+
+        // Assert refund message
+        cy.get('.govuk-radios__hint')
+          .first()
+          .should(
+            'contain',
+            `Refund the full amount of ${convertPenceToPoundsFormatted(transactionDetails.refund_summary_available)}`
+          )
       })
     })
 
-    it('should display dispute details', () => {
-      const disputedPaymentDetails = defaultTransactionDetails()
-      disputedPaymentDetails.disputed = true
-      disputedPaymentDetails.refund_summary_status = 'unavailable'
-      const disputeTransactionDetails = defaultDisputeDetails()
+    describe('Disputed payment', () => {
+      it('should display won dispute with positive amount in transaction details', () => {
+        const disputedPaymentDetails = defaultTransactionDetails()
+        disputedPaymentDetails.disputed = true
 
-      cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
-      cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+        disputedPaymentDetails.events = [
+          {
+            type: 'PAYMENT',
+            status: 'success',
+            finished: true,
+            amount: defaultAmount,
+            timestamp: '2022-07-20T14:45:22.000Z',
+          },
+          {
+            type: 'DISPUTE',
+            status: 'won',
+            finished: true,
+            amount: defaultAmount,
+            timestamp: '2022-07-29T16:30:45.000Z',
+          },
+        ]
 
-      cy.get('.transaction-details tbody')
-        .find('tr')
-        .eq(2)
-        .find('td')
-        .first()
-        .should('contain', 'Dispute lost to customer')
+        const wonDisputeDetails = {
+          parent_transaction_id: transactionId,
+          gateway_account_id: gatewayAccountId,
+          transactions: [
+            {
+              gateway_account_id: gatewayAccountId,
+              amount: 20000,
+              fee: 1500,
+              net_amount: 20000,
+              finished: true,
+              status: 'won',
+              created_date: '2022-07-26T19:57:26.000Z',
+              type: 'dispute',
+              includePaymentDetails: true,
+              evidence_due_date: '2022-08-04T13:59:59.000Z',
+              reason: 'product_not_received',
+              transaction_id: disputeTransactionId,
+              parent_transaction_id: transactionId,
+            },
+          ],
+        }
 
-      cy.get('[data-cy=dispute-details]').contains('Dispute details').should('exist')
-      cy.get('[data-cy=dispute-details-container]').within(() => {
-        cy.get('[data-cy=dispute-state]').contains('Dispute lost to customer').should('exist')
-        cy.get('[data-cy=dispute-amount]').contains('£200.00').should('exist')
-        cy.get('[data-cy=dispute-net-amount]').contains('-£215.00').should('exist')
-        cy.get('[data-cy=dispute-fee]').invoke('text').should('contain', '£15.00')
-        cy.get('[data-cy=dispute-reason]').contains('Product not received').should('exist')
-        cy.get('[data-cy=dispute-date]').contains(utcToDisplay('2022-07-26T19:57:26.000Z')).should('exist')
-        cy.get('[data-cy=dispute-evidence-due-date]').contains(utcToDisplay('2022-08-04T13:59:59.000Z')).should('exist')
+        cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, wonDisputeDetails))
+        cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .first()
+          .should('contain', 'Dispute won in your favour')
+
+        cy.get('.transaction-events tbody tr')
+          .contains(formatDate(new Date(disputedPaymentDetails.events[1].timestamp)))
+          .closest('tr')
+          .find('td')
+          .eq(1)
+          .should('contain', '£10.00')
+          .should('not.contain', '–£10.00')
+
+        cy.get('[data-cy=dispute-details]').contains('Dispute details').should('exist')
+        cy.get('[data-cy=dispute-details-container]').within(() => {
+          cy.get('[data-cy=dispute-state]').contains('Dispute won in your favour').should('exist')
+          cy.get('[data-cy=dispute-amount]').contains('£200.00').should('exist')
+          cy.get('[data-cy=dispute-net-amount]').contains('£200.00').should('exist')
+        })
+      })
+
+      it('should show refund unavailable message', () => {
+        const disputedPaymentDetails = defaultTransactionDetails()
+        disputedPaymentDetails.disputed = true
+        disputedPaymentDetails.refund_summary_status = 'unavailable'
+        const disputeTransactionDetails = defaultDisputeDetails()
+
+        cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
+        cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+
+        cy.get('[data-cy=refund-container]').within(() => {
+          cy.get('h2').contains('Refund').should('exist')
+          cy.get('#refundForm').should('not.exist')
+
+          cy.get('p').contains('You cannot refund this payment because it is being disputed.')
+        })
+      })
+
+      it('should display dispute details', () => {
+        const disputedPaymentDetails = defaultTransactionDetails()
+        disputedPaymentDetails.disputed = true
+        disputedPaymentDetails.refund_summary_status = 'unavailable'
+        const disputeTransactionDetails = defaultDisputeDetails()
+
+        cy.task('setupStubs', getStubs(disputedPaymentDetails, {}, disputeTransactionDetails))
+        cy.visit(`${transactionsUrl}/${disputedPaymentDetails.transaction_id}`)
+
+        cy.get('.transaction-details tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .first()
+          .should('contain', 'Dispute lost to customer')
+
+        cy.get('[data-cy=dispute-details]').contains('Dispute details').should('exist')
+        cy.get('[data-cy=dispute-details-container]').within(() => {
+          cy.get('[data-cy=dispute-state]').contains('Dispute lost to customer').should('exist')
+          cy.get('[data-cy=dispute-amount]').contains('£200.00').should('exist')
+          cy.get('[data-cy=dispute-net-amount]').contains('-£215.00').should('exist')
+          cy.get('[data-cy=dispute-fee]').invoke('text').should('contain', '£15.00')
+          cy.get('[data-cy=dispute-reason]').contains('Product not received').should('exist')
+          cy.get('[data-cy=dispute-date]').contains(utcToDisplay('2022-07-26T19:57:26.000Z')).should('exist')
+          cy.get('[data-cy=dispute-evidence-due-date]')
+            .contains(utcToDisplay('2022-08-04T13:59:59.000Z'))
+            .should('exist')
+        })
       })
     })
   })

--- a/test/cypress/integration/transactions/transaction-list-pagination.cy.js
+++ b/test/cypress/integration/transactions/transaction-list-pagination.cy.js
@@ -4,7 +4,7 @@ const userStubs = require('../../stubs/user-stubs')
 const gatewayAccountStubs = require('../../stubs/gateway-account-stubs')
 const transactionStubs = require('../../stubs/transaction-stubs')
 
-describe('Transactions list pagination', () => {
+describe.skip('Transactions list pagination', () => {
   const userExternalId = 'cd0fa54cf3b7408a80ae2f1b93e7c16e'
   const gatewayAccountId = 42
   const gatewayAccountExternalId = 'a-valid-external-id'

--- a/test/cypress/integration/transactions/transaction-search.cy.js
+++ b/test/cypress/integration/transactions/transaction-search.cy.js
@@ -10,39 +10,39 @@ const gatewayAccountExternalId = 'a-valid-external-id'
 const serviceName = 'Test Service'
 const transactionsUrl = `/account/${gatewayAccountExternalId}/transactions`
 
-const convertPenceToPoundsFormatted = pence => `£${(pence / 100).toFixed(2)}`
+const convertPenceToPoundsFormatted = (pence) => `£${(pence / 100).toFixed(2)}`
 
 const unfilteredTransactions = [
   {
     reference: 'unfiltered1',
     amount: 1000,
-    type: 'payment'
+    type: 'payment',
   },
   {
     reference: 'unfiltered2',
     amount: 2000,
-    type: 'payment'
+    type: 'payment',
   },
   {
     reference: 'unfiltered3',
     amount: 3000,
     corporate_card_surcharge: 250,
     total_amount: 3250,
-    type: 'payment'
-  }
+    type: 'payment',
+  },
 ]
 
 const filteredByDatesTransactions = [
   {
     reference: 'filtered-by-from-date1',
     amount: 1000,
-    type: 'payment'
+    type: 'payment',
   },
   {
     reference: 'filtered-by-from-date2',
     amount: 1500,
-    type: 'payment'
-  }
+    type: 'payment',
+  },
 ]
 
 const filteredByMultipleFieldsTransactions = [
@@ -51,7 +51,7 @@ const filteredByMultipleFieldsTransactions = [
     reference: 'filtered-by-multiple-fields',
     amount: 1500,
     type: 'payment',
-    card_brand: 'Mastercard'
+    card_brand: 'Mastercard',
   },
   {
     amount: 1500,
@@ -59,8 +59,8 @@ const filteredByMultipleFieldsTransactions = [
     type: 'refund',
     includePaymentDetails: true,
     status: 'submitted',
-    parent_transaction_id: 'payment-transaction-id2'
-  }
+    parent_transaction_id: 'payment-transaction-id2',
+  },
 ]
 const transactionWithTotalAmountButNotNetAmount = [
   {
@@ -68,8 +68,8 @@ const transactionWithTotalAmountButNotNetAmount = [
     reference: 'ref-1',
     amount: 100,
     total_amount: 100,
-    type: 'payment'
-  }
+    type: 'payment',
+  },
 ]
 
 const transactionsWithAssociatedFees = [
@@ -79,7 +79,7 @@ const transactionsWithAssociatedFees = [
     fee: 300,
     net_amount: 2700,
     type: 'payment',
-    payment_provider: 'stripe'
+    payment_provider: 'stripe',
   },
   {
     reference: 'second-transaction-with-fee',
@@ -87,8 +87,8 @@ const transactionsWithAssociatedFees = [
     fee: 500,
     net_amount: 4500,
     type: 'payment',
-    payment_provider: 'stripe'
-  }
+    payment_provider: 'stripe',
+  },
 ]
 
 const disputeTransactions = [
@@ -101,7 +101,7 @@ const disputeTransactions = [
     type: 'dispute',
     includePaymentDetails: true,
     status: 'needs_response',
-    amount: 2500
+    amount: 2500,
   },
   {
     gateway_account_id: gatewayAccountId,
@@ -114,8 +114,8 @@ const disputeTransactions = [
     status: 'lost',
     amount: 3500,
     net_amount: -5000,
-    fee: 1500
-  }
+    fee: 1500,
+  },
 ]
 
 const disputeTransactionsWithWonState = [
@@ -128,7 +128,7 @@ const disputeTransactionsWithWonState = [
     type: 'dispute',
     includePaymentDetails: true,
     status: 'needs_response',
-    amount: 2500
+    amount: 2500,
   },
   {
     gateway_account_id: gatewayAccountId,
@@ -139,7 +139,7 @@ const disputeTransactionsWithWonState = [
     type: 'dispute',
     includePaymentDetails: true,
     status: 'won',
-    amount: 3500
+    amount: 3500,
   },
   {
     gateway_account_id: gatewayAccountId,
@@ -150,8 +150,8 @@ const disputeTransactionsWithWonState = [
     type: 'dispute',
     includePaymentDetails: true,
     status: 'lost',
-    amount: 4500
-  }
+    amount: 4500,
+  },
 ]
 
 const sharedStubs = (paymentProvider = 'sandbox') => {
@@ -163,16 +163,19 @@ const sharedStubs = (paymentProvider = 'sandbox') => {
       gatewayAccountExternalId,
       paymentProvider,
       type: 'live',
-      recurringEnabled: true
+      recurringEnabled: true,
     }),
     gatewayAccountStubs.getCardTypesSuccess(),
-    stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId })
+    stripeAccountSetupStubs.getGatewayAccountStripeSetupSuccess({ gatewayAccountId }),
   ]
 }
 
-function assertTransactionRow (row, reference, transactionLink, email, amount, cardBrand, state, fee, netAmount) {
+function assertTransactionRow(row, reference, transactionLink, email, amount, cardBrand, state, fee, netAmount) {
   cy.get('#transactions-list tbody').find('tr').eq(row).find('th').should('contain', reference)
-  cy.get('#transactions-list tbody').find('tr > th').eq(row).find('.reference')
+  cy.get('#transactions-list tbody')
+    .find('tr > th')
+    .eq(row)
+    .find('.reference')
     .should('have.attr', 'href', transactionLink)
   cy.get('#transactions-list tbody').find('tr').eq(row).find('.email').should('contain', email)
   cy.get('#transactions-list tbody').find('tr').eq(row).find('.amount').should('contain', amount)
@@ -180,7 +183,13 @@ function assertTransactionRow (row, reference, transactionLink, email, amount, c
   cy.get('#transactions-list tbody').find('tr').eq(row).find('.state').should('contain', state)
 
   if (netAmount) {
-    cy.get('#transactions-list tbody').find('tr').eq(row).get('[data-cell-type="net"]').eq(row).find('span').should('have.text', netAmount)
+    cy.get('#transactions-list tbody')
+      .find('tr')
+      .eq(row)
+      .get('[data-cell-type="net"]')
+      .eq(row)
+      .find('span')
+      .should('have.text', netAmount)
   }
 
   if (fee) {
@@ -193,520 +202,663 @@ describe('Transactions List', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('Filtering', () => {
-    it('should display correctly when there are no results', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId })
-      ])
-      cy.visit(transactionsUrl)
-      cy.get('#transactions-list tbody').should('not.exist')
-    })
-
-    it('should check if the user has entered a potential PAN into the reference field', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId })
-      ])
-      cy.visit(transactionsUrl)
-
-      cy.get('[data-cy=reference-filter]').type('4242424242424242')
-      cy.get('[data-cy=email-filter]').click()
-
-      cy.get('[data-cy=reference-filter]').parent().should('have.class', 'govuk-form-group--error')
-      cy.get('[data-cy=pan-error]').should('exist')
-
-      cy.get('[data-cy=reference-filter]').clear()
-      cy.get('[data-cy=reference-filter]').type('a123456789012345')
-      cy.get('[data-cy=email-filter]').click()
-
-      cy.get('[data-cy=reference-filter]').parent().should('not.have.class', 'govuk-form-group--error')
-      cy.get('[data-cy=pan-error]').should('not.exist')
-
-      cy.get('[data-cy=reference-filter]').clear()
-      cy.get('[data-cy=reference-filter]').type('4444333322221111')
-      cy.get('[data-cy=email-filter]').click()
-
-      cy.get('[data-cy=reference-filter]').parent().should('have.class', 'govuk-form-group--error')
-      cy.get('[data-cy=pan-error]').should('exist')
-    })
-
-    it('should display unfiltered results', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions })
-      ])
-      cy.visit(transactionsUrl)
-
-      // Ensure the transactions list has the right number of items
-      cy.get('#transactions-list tbody').find('tr').should('have.length', unfilteredTransactions.length)
-
-      // Ensure the expected transactions are shown
-      cy.get('#transactions-list tbody').find('tr').first().find('th').should('contain', unfilteredTransactions[0].reference)
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('th').should('contain', unfilteredTransactions[1].reference)
-      cy.get('#transactions-list tbody').find('tr').eq(2).find('th').should('contain', unfilteredTransactions[2].reference)
-    })
-
-    it('should be able to filter using date-time pickers', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: filteredByDatesTransactions,
-          filters: {
-            from_date: '2018-05-03T00:00:00.000Z',
-            to_date: '2018-05-03T00:00:01.000Z'
-          }
-        })
-      ])
-      cy.visit(transactionsUrl)
-
-      // 1. Filtering FROM
-      // Ensure both the date/time pickers aren't showing
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('not.exist')
-
-      // Fill in a from date
-      cy.get('#fromDate').type('03/5/2018')
-
-      // Ensure only the datepicker is showing
-      cy.get('.datepicker').should('be.visible')
-      cy.get('.ui-timepicker-wrapper').should('not.exist')
-
-      // Fill in a from time
-      cy.get('#fromTime').type('01:00:00')
-
-      // Ensure only the timepicker is showing
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('be.visible')
-
-      // 2. Filtering TO
-
-      // Fill in a to date
-      cy.get('#toDate').type('03/5/2018')
-
-      // Ensure only the datepicker is showing
-      cy.get('.datepicker').should('be.visible')
-      cy.get('.ui-timepicker-wrapper').should('not.be.visible')
-
-      // Fill in a to time
-      cy.get('#toTime').type('01:00:00')
-
-      // Ensure only the timepicker is showing
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('be.visible')
-
-      // Click the filter button
-      cy.get('#filter').click()
-
-      // Ensure the right number of transactions is displayed
-      cy.get('#transactions-list tbody').find('tr').should('have.length', filteredByDatesTransactions.length)
-
-      // Ensure the expected transactions are shown
-      cy.get('#transactions-list tbody').find('tr').first().find('th').should('contain', filteredByDatesTransactions[0].reference)
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('th').should('contain', filteredByDatesTransactions[1].reference)
-
-      // Ensure filters are cleared when "Clear filter" is clicked
-      cy.get('a').contains('Clear filter').click()
-
-      cy.get('#fromDate').should('be.empty')
-      cy.get('#fromTime').should('be.empty')
-      cy.get('#toDate').should('be.empty')
-      cy.get('#toTime').should('be.empty')
-    })
-
-    it('should return results when filtering by all fields', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: filteredByMultipleFieldsTransactions,
-          filters: {
-            reference: 'ref123',
-            from_date: '2018-05-03T00:00:00.000Z',
-            to_date: '2018-05-04T00:00:01.000Z',
-            payment_states: 'created,started,submitted,capturable,success',
-            email: 'gds4',
-            card_brands: 'visa,master-card',
-            last_digits_card_number: '4242',
-            cardholder_name: 'doe',
-            refund_states: 'submitted',
-            metadata_value: 'test',
-            agreement_id: 'an-agreement-id'
-          }
-        })
-      ])
-
-      cy.visit(transactionsUrl)
-      cy.get('#state').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Success\']').trigger('mouseover').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'In progress\']').trigger('mouseover').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Refund submitted\']').trigger('mouseover').click()
-
-      cy.get('#reference').type('ref123')
-      cy.get('#fromDate').type('03/5/2018')
-      cy.get('#fromTime').type('01:00:00')
-      cy.get('#toDate').type('04/5/2018')
-      cy.get('#toTime').type('01:00:00')
-      cy.get('#card-brand').click()
-      cy.get('#list-of-sectors-brand .govuk-checkboxes__input[value=visa]').click()
-      cy.get('#list-of-sectors-brand .govuk-checkboxes__input[value=master-card]').click()
-      cy.get('#email').type('gds4')
-      cy.get('#lastDigitsCardNumber').type('4242')
-      cy.get('#cardholderName').type('doe')
-
-      cy.contains('Advanced filters').click()
-      cy.get('#metadataValue').type('test')
-      cy.get('#agreementId').type('an-agreement-id')
-      cy.get('#filter').click()
-
-      // Ensure the right number of transactions is displayed
-      cy.get('#transactions-list tbody').find('tr').should('have.length', filteredByMultipleFieldsTransactions.length)
-      // Ensure the expected transactions are shown
-      assertTransactionRow(0, filteredByMultipleFieldsTransactions[0].reference, `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id`,
-        'test2@example.org', '£15.00', 'Mastercard', 'In progress')
-      assertTransactionRow(1, filteredByMultipleFieldsTransactions[1].reference, `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id2`,
-        'test@example.org', '–£15.00', 'Visa', 'Refund submitted')
-    })
-
-    it('should display error message when searching with from date later than to date', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: filteredByDatesTransactions,
-          filters: {
-            from_date: '2018-05-03T00:00:00.000Z',
-            to_date: '2018-05-03T00:00:01.000Z'
-          }
-        })
-      ])
-      cy.visit(transactionsUrl)
-
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('not.exist')
-
-      cy.get('#fromDate').type('03/5/2018')
-
-      cy.get('.datepicker').should('be.visible')
-      cy.get('.ui-timepicker-wrapper').should('not.exist')
-
-      cy.get('#fromTime').type('01:00:00')
-
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('be.visible')
-
-      cy.get('#toDate').type('02/5/2018')
-
-      cy.get('.datepicker').should('be.visible')
-      cy.get('.ui-timepicker-wrapper').should('not.be.visible')
-
-      cy.get('#toTime').type('01:00:00')
-
-      cy.get('.datepicker').should('not.exist')
-      cy.get('.ui-timepicker-wrapper').should('be.visible')
-
-      cy.get('#filter').click()
-
-      cy.get('#transactions-list tbody').should('not.exist')
-
-      cy.get('[data-cy=error-summary]').contains('End date must be after start date')
-      cy.get('[data-cy=from-date-error-message]').contains('End date must be after start date')
-      cy.get('[data-cy=from-date-error-message]').parent().should('have.class', 'govuk-form-group--error')
-      cy.get('[data-cy=to-date-field]').should('have.class', 'govuk-input--error')
-    })
-  })
-  describe('Transactions are displayed correctly', () => {
-    it('should display card fee with corporate card surcharge transaction', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: unfilteredTransactions,
-          transactionLength: 1000
-        })
-      ])
-      cy.visit(transactionsUrl)
-
-      // Ensure the transactions list has the right number of items
-      cy.get('#transactions-list tbody').find('tr').should('have.length', unfilteredTransactions.length)
-
-      // Ensure the values are displayed correctly
-      cy.get('#transactions-list tbody').first().find('td').eq(1).should('have.text', convertPenceToPoundsFormatted(unfilteredTransactions[0].amount))
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('td').eq(1).should('have.text', convertPenceToPoundsFormatted(unfilteredTransactions[1].amount))
-
-      // Ensure the card fee is displayed correctly
-      cy.get('#transactions-list tbody').find('tr').eq(2).find('td').eq(1).should('contain', convertPenceToPoundsFormatted(unfilteredTransactions[2].total_amount)).and('contain', '(with card fee)')
-      cy.get('#download-transactions-link').should('have.attr', 'href', `/account/${gatewayAccountExternalId}/transactions/download`)
-    })
-
-    it('should display the fee and total columns for a stripe gateway with fees', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs('stripe'),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: transactionsWithAssociatedFees
-        })
-      ])
-      cy.visit(transactionsUrl)
-
-      cy.get('#transactions-list tbody').find('tr').should('have.length', transactionsWithAssociatedFees.length)
-
-      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="fee"]').first().should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[0].fee))
-      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="net"]').first().find('span').should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[0].amount - transactionsWithAssociatedFees[0].fee))
-
-      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="fee"]').eq(1).should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[1].fee))
-      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="net"]').eq(1).find('span').should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[1].amount - transactionsWithAssociatedFees[1].fee))
-    })
-    it('should display net amount correctly for stripe transaction with total amount but not net amount set', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs('stripe'),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: transactionWithTotalAmountButNotNetAmount
-        })
-      ])
-      cy.visit(transactionsUrl)
-      cy.get('#transactions-list tbody').find('tr').first().get('[data-cell-type="net"]').eq(0).find('span').should('have.text', convertPenceToPoundsFormatted(transactionWithTotalAmountButNotNetAmount[0].total_amount))
-    })
-
-    it('should display dispute statuses in the dropdown and dispute transactions correctly - when enabled', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.task('setupStubs', [
-        ...sharedStubs('stripe'),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: []
-        }),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: disputeTransactions,
-          filters: {
-            dispute_states: 'needs_response,under_review'
-          }
-        })
-      ])
-
-      cy.visit(transactionsUrl)
-
-      cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute awaiting evidence')
-      cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute under review')
-      cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute won in your favour')
-      cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute lost to customer')
-
-      cy.get('#state').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Dispute awaiting evidence\']').trigger('mouseover').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Dispute under review\']').trigger('mouseover').click()
-
-      cy.get('#filter').click()
-      cy.get('.transactions-list--row').should('have.length', 2)
-      cy.get('#charge-id-parent-transaction-id-1').should('exist')
-      cy.get('#charge-id-parent-transaction-id-2').should('exist')
-
-      assertTransactionRow(0, disputeTransactions[0].reference, '/account/a-valid-external-id/transactions/parent-transaction-id-1',
-        'test@example.org', '–£25.00', 'Visa', 'Dispute awaiting evidence', '', '')
-      assertTransactionRow(1, disputeTransactions[1].reference, '/account/a-valid-external-id/transactions/parent-transaction-id-2',
-        'test@example.org', '–£35.00', 'Visa', 'Dispute lost to customer', '£15.00', '-£50.00')
-
-      cy.get('#download-transactions-link').should('have.attr', 'href', '/account/a-valid-external-id/transactions/download?dispute_states=needs_response&dispute_states=under_review')
-    })
-
-    it('should display dispute amounts correctly based on state - only showing minus sign for non-won disputes', () => {
-      cy.setEncryptedCookies(userExternalId)
-      cy.task('setupStubs', [
-        ...sharedStubs('stripe'),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: []
-        }),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: disputeTransactionsWithWonState,
-          filters: {
-            dispute_states: 'needs_response,won,lost'
-          }
-        })
-      ])
-
-      cy.visit(transactionsUrl)
-
-      cy.get('#state').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Dispute awaiting evidence\']').trigger('mouseover').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Dispute won in your favour\']').trigger('mouseover').click()
-      cy.get('#list-of-sectors-state .govuk-checkboxes__input[value=\'Dispute lost to customer\']').trigger('mouseover').click()
-
-      cy.get('#filter').click()
-      cy.get('.transactions-list--row').should('have.length', 3)
-
-      cy.get('#charge-id-parent-transaction-id-1').should('exist')
-      cy.get('#charge-id-parent-transaction-id-2').should('exist')
-      cy.get('#charge-id-parent-transaction-id-3').should('exist')
-
-      cy.get('#transactions-list tbody').find('tr').eq(0).find('.amount').should('contain', '–£25.00')
-      cy.get('#transactions-list tbody').find('tr').eq(0).find('.state').should('contain', 'Dispute awaiting evidence')
-
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('.amount').should('not.contain', '–£')
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('.amount').should('contain', '£35.00')
-      cy.get('#transactions-list tbody').find('tr').eq(1).find('.state').should('contain', 'Dispute won in your favour')
-
-      cy.get('#transactions-list tbody').find('tr').eq(2).find('.amount').should('contain', '–£45.00')
-      cy.get('#transactions-list tbody').find('tr').eq(2).find('.state').should('contain', 'Dispute lost to customer')
+  describe('redirect', () => {
+    it('should redirect to the new transactions page', () => {
+      cy.task('setupStubs', [...sharedStubs(), transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId })])
+      cy.request({
+        url: transactionsUrl,
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        expect(response.headers.location).to.eq('/service/cp5wa/account/live/transactions')
+      })
     })
   })
 
-  describe('csv download link', () => {
-    it('should not display csv download link when results >5k and no filter applied', function () {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: unfilteredTransactions,
-          transactionLength: 5001
-        })
-      ])
-      cy.visit(transactionsUrl)
+  describe.skip('skipping old tests', () => {
+    describe('Filtering', () => {
+      it('should display correctly when there are no results', () => {
+        cy.task('setupStubs', [...sharedStubs(), transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId })])
+        cy.visit(transactionsUrl)
+        cy.get('#transactions-list tbody').should('not.exist')
+      })
 
-      cy.get('#download-transactions-link').should('not.exist')
-      cy.get('#csv-download').should('contain', 'Filter results to download a CSV of transactions')
+      it('should check if the user has entered a potential PAN into the reference field', () => {
+        cy.task('setupStubs', [...sharedStubs(), transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId })])
+        cy.visit(transactionsUrl)
+
+        cy.get('[data-cy=reference-filter]').type('4242424242424242')
+        cy.get('[data-cy=email-filter]').click()
+
+        cy.get('[data-cy=reference-filter]').parent().should('have.class', 'govuk-form-group--error')
+        cy.get('[data-cy=pan-error]').should('exist')
+
+        cy.get('[data-cy=reference-filter]').clear()
+        cy.get('[data-cy=reference-filter]').type('a123456789012345')
+        cy.get('[data-cy=email-filter]').click()
+
+        cy.get('[data-cy=reference-filter]').parent().should('not.have.class', 'govuk-form-group--error')
+        cy.get('[data-cy=pan-error]').should('not.exist')
+
+        cy.get('[data-cy=reference-filter]').clear()
+        cy.get('[data-cy=reference-filter]').type('4444333322221111')
+        cy.get('[data-cy=email-filter]').click()
+
+        cy.get('[data-cy=reference-filter]').parent().should('have.class', 'govuk-form-group--error')
+        cy.get('[data-cy=pan-error]').should('exist')
+      })
+
+      it('should display unfiltered results', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+        ])
+        cy.visit(transactionsUrl)
+
+        // Ensure the transactions list has the right number of items
+        cy.get('#transactions-list tbody').find('tr').should('have.length', unfilteredTransactions.length)
+
+        // Ensure the expected transactions are shown
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .find('th')
+          .should('contain', unfilteredTransactions[0].reference)
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(1)
+          .find('th')
+          .should('contain', unfilteredTransactions[1].reference)
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(2)
+          .find('th')
+          .should('contain', unfilteredTransactions[2].reference)
+      })
+
+      it('should be able to filter using date-time pickers', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: filteredByDatesTransactions,
+            filters: {
+              from_date: '2018-05-03T00:00:00.000Z',
+              to_date: '2018-05-03T00:00:01.000Z',
+            },
+          }),
+        ])
+        cy.visit(transactionsUrl)
+
+        // 1. Filtering FROM
+        // Ensure both the date/time pickers aren't showing
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('not.exist')
+
+        // Fill in a from date
+        cy.get('#fromDate').type('03/5/2018')
+
+        // Ensure only the datepicker is showing
+        cy.get('.datepicker').should('be.visible')
+        cy.get('.ui-timepicker-wrapper').should('not.exist')
+
+        // Fill in a from time
+        cy.get('#fromTime').type('01:00:00')
+
+        // Ensure only the timepicker is showing
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('be.visible')
+
+        // 2. Filtering TO
+
+        // Fill in a to date
+        cy.get('#toDate').type('03/5/2018')
+
+        // Ensure only the datepicker is showing
+        cy.get('.datepicker').should('be.visible')
+        cy.get('.ui-timepicker-wrapper').should('not.be.visible')
+
+        // Fill in a to time
+        cy.get('#toTime').type('01:00:00')
+
+        // Ensure only the timepicker is showing
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('be.visible')
+
+        // Click the filter button
+        cy.get('#filter').click()
+
+        // Ensure the right number of transactions is displayed
+        cy.get('#transactions-list tbody').find('tr').should('have.length', filteredByDatesTransactions.length)
+
+        // Ensure the expected transactions are shown
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .find('th')
+          .should('contain', filteredByDatesTransactions[0].reference)
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(1)
+          .find('th')
+          .should('contain', filteredByDatesTransactions[1].reference)
+
+        // Ensure filters are cleared when "Clear filter" is clicked
+        cy.get('a').contains('Clear filter').click()
+
+        cy.get('#fromDate').should('be.empty')
+        cy.get('#fromTime').should('be.empty')
+        cy.get('#toDate').should('be.empty')
+        cy.get('#toTime').should('be.empty')
+      })
+
+      it('should return results when filtering by all fields', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: filteredByMultipleFieldsTransactions,
+            filters: {
+              reference: 'ref123',
+              from_date: '2018-05-03T00:00:00.000Z',
+              to_date: '2018-05-04T00:00:01.000Z',
+              payment_states: 'created,started,submitted,capturable,success',
+              email: 'gds4',
+              card_brands: 'visa,master-card',
+              last_digits_card_number: '4242',
+              cardholder_name: 'doe',
+              refund_states: 'submitted',
+              metadata_value: 'test',
+              agreement_id: 'an-agreement-id',
+            },
+          }),
+        ])
+
+        cy.visit(transactionsUrl)
+        cy.get('#state').click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Success']").trigger('mouseover').click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='In progress']").trigger('mouseover').click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Refund submitted']").trigger('mouseover').click()
+
+        cy.get('#reference').type('ref123')
+        cy.get('#fromDate').type('03/5/2018')
+        cy.get('#fromTime').type('01:00:00')
+        cy.get('#toDate').type('04/5/2018')
+        cy.get('#toTime').type('01:00:00')
+        cy.get('#card-brand').click()
+        cy.get('#list-of-sectors-brand .govuk-checkboxes__input[value=visa]').click()
+        cy.get('#list-of-sectors-brand .govuk-checkboxes__input[value=master-card]').click()
+        cy.get('#email').type('gds4')
+        cy.get('#lastDigitsCardNumber').type('4242')
+        cy.get('#cardholderName').type('doe')
+
+        cy.contains('Advanced filters').click()
+        cy.get('#metadataValue').type('test')
+        cy.get('#agreementId').type('an-agreement-id')
+        cy.get('#filter').click()
+
+        // Ensure the right number of transactions is displayed
+        cy.get('#transactions-list tbody').find('tr').should('have.length', filteredByMultipleFieldsTransactions.length)
+        // Ensure the expected transactions are shown
+        assertTransactionRow(
+          0,
+          filteredByMultipleFieldsTransactions[0].reference,
+          `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id`,
+          'test2@example.org',
+          '£15.00',
+          'Mastercard',
+          'In progress'
+        )
+        assertTransactionRow(
+          1,
+          filteredByMultipleFieldsTransactions[1].reference,
+          `/account/${gatewayAccountExternalId}/transactions/payment-transaction-id2`,
+          'test@example.org',
+          '–£15.00',
+          'Visa',
+          'Refund submitted'
+        )
+      })
+
+      it('should display error message when searching with from date later than to date', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: filteredByDatesTransactions,
+            filters: {
+              from_date: '2018-05-03T00:00:00.000Z',
+              to_date: '2018-05-03T00:00:01.000Z',
+            },
+          }),
+        ])
+        cy.visit(transactionsUrl)
+
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('not.exist')
+
+        cy.get('#fromDate').type('03/5/2018')
+
+        cy.get('.datepicker').should('be.visible')
+        cy.get('.ui-timepicker-wrapper').should('not.exist')
+
+        cy.get('#fromTime').type('01:00:00')
+
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('be.visible')
+
+        cy.get('#toDate').type('02/5/2018')
+
+        cy.get('.datepicker').should('be.visible')
+        cy.get('.ui-timepicker-wrapper').should('not.be.visible')
+
+        cy.get('#toTime').type('01:00:00')
+
+        cy.get('.datepicker').should('not.exist')
+        cy.get('.ui-timepicker-wrapper').should('be.visible')
+
+        cy.get('#filter').click()
+
+        cy.get('#transactions-list tbody').should('not.exist')
+
+        cy.get('[data-cy=error-summary]').contains('End date must be after start date')
+        cy.get('[data-cy=from-date-error-message]').contains('End date must be after start date')
+        cy.get('[data-cy=from-date-error-message]').parent().should('have.class', 'govuk-form-group--error')
+        cy.get('[data-cy=to-date-field]').should('have.class', 'govuk-input--error')
+      })
+    })
+    describe('Transactions are displayed correctly', () => {
+      it('should display card fee with corporate card surcharge transaction', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: unfilteredTransactions,
+            transactionLength: 1000,
+          }),
+        ])
+        cy.visit(transactionsUrl)
+
+        // Ensure the transactions list has the right number of items
+        cy.get('#transactions-list tbody').find('tr').should('have.length', unfilteredTransactions.length)
+
+        // Ensure the values are displayed correctly
+        cy.get('#transactions-list tbody')
+          .first()
+          .find('td')
+          .eq(1)
+          .should('have.text', convertPenceToPoundsFormatted(unfilteredTransactions[0].amount))
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(1)
+          .find('td')
+          .eq(1)
+          .should('have.text', convertPenceToPoundsFormatted(unfilteredTransactions[1].amount))
+
+        // Ensure the card fee is displayed correctly
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(2)
+          .find('td')
+          .eq(1)
+          .should('contain', convertPenceToPoundsFormatted(unfilteredTransactions[2].total_amount))
+          .and('contain', '(with card fee)')
+        cy.get('#download-transactions-link').should(
+          'have.attr',
+          'href',
+          `/account/${gatewayAccountExternalId}/transactions/download`
+        )
+      })
+
+      it('should display the fee and total columns for a stripe gateway with fees', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs('stripe'),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: transactionsWithAssociatedFees,
+          }),
+        ])
+        cy.visit(transactionsUrl)
+
+        cy.get('#transactions-list tbody').find('tr').should('have.length', transactionsWithAssociatedFees.length)
+
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .get('[data-cell-type="fee"]')
+          .first()
+          .should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[0].fee))
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .get('[data-cell-type="net"]')
+          .first()
+          .find('span')
+          .should(
+            'have.text',
+            convertPenceToPoundsFormatted(
+              transactionsWithAssociatedFees[0].amount - transactionsWithAssociatedFees[0].fee
+            )
+          )
+
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .get('[data-cell-type="fee"]')
+          .eq(1)
+          .should('have.text', convertPenceToPoundsFormatted(transactionsWithAssociatedFees[1].fee))
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .get('[data-cell-type="net"]')
+          .eq(1)
+          .find('span')
+          .should(
+            'have.text',
+            convertPenceToPoundsFormatted(
+              transactionsWithAssociatedFees[1].amount - transactionsWithAssociatedFees[1].fee
+            )
+          )
+      })
+      it('should display net amount correctly for stripe transaction with total amount but not net amount set', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs('stripe'),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: transactionWithTotalAmountButNotNetAmount,
+          }),
+        ])
+        cy.visit(transactionsUrl)
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .first()
+          .get('[data-cell-type="net"]')
+          .eq(0)
+          .find('span')
+          .should('have.text', convertPenceToPoundsFormatted(transactionWithTotalAmountButNotNetAmount[0].total_amount))
+      })
+
+      it('should display dispute statuses in the dropdown and dispute transactions correctly - when enabled', () => {
+        cy.setEncryptedCookies(userExternalId)
+        cy.task('setupStubs', [
+          ...sharedStubs('stripe'),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: [],
+          }),
+          transactionStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: disputeTransactions,
+            filters: {
+              dispute_states: 'needs_response,under_review',
+            },
+          }),
+        ])
+
+        cy.visit(transactionsUrl)
+
+        cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute awaiting evidence')
+        cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute under review')
+        cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute won in your favour')
+        cy.get('#list-of-sectors-state').invoke('text').should('contain', 'Dispute lost to customer')
+
+        cy.get('#state').click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Dispute awaiting evidence']")
+          .trigger('mouseover')
+          .click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Dispute under review']")
+          .trigger('mouseover')
+          .click()
+
+        cy.get('#filter').click()
+        cy.get('.transactions-list--row').should('have.length', 2)
+        cy.get('#charge-id-parent-transaction-id-1').should('exist')
+        cy.get('#charge-id-parent-transaction-id-2').should('exist')
+
+        assertTransactionRow(
+          0,
+          disputeTransactions[0].reference,
+          '/account/a-valid-external-id/transactions/parent-transaction-id-1',
+          'test@example.org',
+          '–£25.00',
+          'Visa',
+          'Dispute awaiting evidence',
+          '',
+          ''
+        )
+        assertTransactionRow(
+          1,
+          disputeTransactions[1].reference,
+          '/account/a-valid-external-id/transactions/parent-transaction-id-2',
+          'test@example.org',
+          '–£35.00',
+          'Visa',
+          'Dispute lost to customer',
+          '£15.00',
+          '-£50.00'
+        )
+
+        cy.get('#download-transactions-link').should(
+          'have.attr',
+          'href',
+          '/account/a-valid-external-id/transactions/download?dispute_states=needs_response&dispute_states=under_review'
+        )
+      })
+
+      it('should display dispute amounts correctly based on state - only showing minus sign for non-won disputes', () => {
+        cy.setEncryptedCookies(userExternalId)
+        cy.task('setupStubs', [
+          ...sharedStubs('stripe'),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: [],
+          }),
+          transactionStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: disputeTransactionsWithWonState,
+            filters: {
+              dispute_states: 'needs_response,won,lost',
+            },
+          }),
+        ])
+
+        cy.visit(transactionsUrl)
+
+        cy.get('#state').click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Dispute awaiting evidence']")
+          .trigger('mouseover')
+          .click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Dispute won in your favour']")
+          .trigger('mouseover')
+          .click()
+        cy.get("#list-of-sectors-state .govuk-checkboxes__input[value='Dispute lost to customer']")
+          .trigger('mouseover')
+          .click()
+
+        cy.get('#filter').click()
+        cy.get('.transactions-list--row').should('have.length', 3)
+
+        cy.get('#charge-id-parent-transaction-id-1').should('exist')
+        cy.get('#charge-id-parent-transaction-id-2').should('exist')
+        cy.get('#charge-id-parent-transaction-id-3').should('exist')
+
+        cy.get('#transactions-list tbody').find('tr').eq(0).find('.amount').should('contain', '–£25.00')
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(0)
+          .find('.state')
+          .should('contain', 'Dispute awaiting evidence')
+
+        cy.get('#transactions-list tbody').find('tr').eq(1).find('.amount').should('not.contain', '–£')
+        cy.get('#transactions-list tbody').find('tr').eq(1).find('.amount').should('contain', '£35.00')
+        cy.get('#transactions-list tbody')
+          .find('tr')
+          .eq(1)
+          .find('.state')
+          .should('contain', 'Dispute won in your favour')
+
+        cy.get('#transactions-list tbody').find('tr').eq(2).find('.amount').should('contain', '–£45.00')
+        cy.get('#transactions-list tbody').find('tr').eq(2).find('.state').should('contain', 'Dispute lost to customer')
+      })
     })
 
-    it('should display csv download link when results >5k and filters applied', function () {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId,
-          transactions: unfilteredTransactions,
-          transactionLength: 10001,
-          filters: { reference: 'unfiltered' }
-        })
-      ])
-      cy.visit(transactionsUrl + '?reference=unfiltered')
+    describe('csv download link', () => {
+      it('should not display csv download link when results >5k and no filter applied', function () {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: unfilteredTransactions,
+            transactionLength: 5001,
+          }),
+        ])
+        cy.visit(transactionsUrl)
 
-      cy.get('#download-transactions-link').should('exist')
-    })
-  })
+        cy.get('#download-transactions-link').should('not.exist')
+        cy.get('#csv-download').should('contain', 'Filter results to download a CSV of transactions')
+      })
 
-  describe('Should display relevant error page on search failure ', () => {
-    it('should show error message on a bad request while retrieving the list of transactions', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions })
-      ])
-      cy.visit(transactionsUrl, { failOnStatusCode: false })
+      it('should display csv download link when results >5k and filters applied', function () {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({
+            gatewayAccountId,
+            transactions: unfilteredTransactions,
+            transactionLength: 10001,
+            filters: { reference: 'unfiltered' },
+          }),
+        ])
+        cy.visit(transactionsUrl + '?reference=unfiltered')
 
-      cy.task('clearStubs')
-
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsFailure(
-          {
-            account_id: gatewayAccountId,
-            limit_total: 'true',
-            limit_total_size: '5001',
-            from_date: '',
-            to_date: '',
-            page: '1',
-            display_size: '100'
-          },
-          400)
-      ])
-
-      // Click the filter button
-      cy.get('#filter').click()
-
-      // Ensure that transaction list is not displayed
-      cy.get('#transactions-list tbody').should('not.exist')
-
-      // Ensure an error message header is displayed
-      cy.get('h1').contains('An error occurred')
-
-      // Ensure a generic error message is displayed
-      cy.get('#errorMsg').contains('There is a problem with the payments platform. Please contact the support team.')
+        cy.get('#download-transactions-link').should('exist')
+      })
     })
 
-    it('should display the generic error page, if an internal server error occurs while retrieving the list of transactions', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions })
-      ])
-      cy.visit(transactionsUrl, { failOnStatusCode: false })
+    describe('Should display relevant error page on search failure ', () => {
+      it('should show error message on a bad request while retrieving the list of transactions', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+        ])
+        cy.visit(transactionsUrl, { failOnStatusCode: false })
 
-      cy.task('clearStubs')
+        cy.task('clearStubs')
 
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsFailure(
-          {
-            account_id: gatewayAccountId,
-            limit_total: 'true',
-            limit_total_size: '5001',
-            from_date: '',
-            to_date: '',
-            page: '1',
-            display_size: '100'
-          },
-          500)
-      ])
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsFailure(
+            {
+              account_id: gatewayAccountId,
+              limit_total: 'true',
+              limit_total_size: '5001',
+              from_date: '',
+              to_date: '',
+              page: '1',
+              display_size: '100',
+            },
+            400
+          ),
+        ])
 
-      // Click the filter button
-      cy.get('#filter').click()
+        // Click the filter button
+        cy.get('#filter').click()
 
-      // Ensure that transaction list is not displayed
-      cy.get('#transactions-list tbody').should('not.exist')
+        // Ensure that transaction list is not displayed
+        cy.get('#transactions-list tbody').should('not.exist')
 
-      // Ensure an error message header is displayed
-      cy.get('h1').contains('An error occurred')
+        // Ensure an error message header is displayed
+        cy.get('h1').contains('An error occurred')
 
-      // Ensure a generic error message is displayed
-      cy.get('#errorMsg').contains('There is a problem with the payments platform. Please contact the support team.')
-    })
+        // Ensure a generic error message is displayed
+        cy.get('#errorMsg').contains('There is a problem with the payments platform. Please contact the support team.')
+      })
 
-    it('should display the gateway timeout error page, if a gateway timeout error occurs while retrieving the list of transactions', () => {
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions })
-      ])
+      it('should display the generic error page, if an internal server error occurs while retrieving the list of transactions', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+        ])
+        cy.visit(transactionsUrl, { failOnStatusCode: false })
 
-      cy.visit(transactionsUrl, { failOnStatusCode: false })
+        cy.task('clearStubs')
 
-      // Fill from and to date
-      cy.get('#fromDate').type('03/5/2018')
-      cy.get('#fromTime').type('01:00:00')
-      cy.get('#toDate').type('03/5/2023')
-      cy.get('#toTime').type('01:00:00')
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsFailure(
+            {
+              account_id: gatewayAccountId,
+              limit_total: 'true',
+              limit_total_size: '5001',
+              from_date: '',
+              to_date: '',
+              page: '1',
+              display_size: '100',
+            },
+            500
+          ),
+        ])
 
-      // 1. Filtering
-      cy.task('clearStubs')
+        // Click the filter button
+        cy.get('#filter').click()
 
-      cy.task('setupStubs', [
-        ...sharedStubs(),
-        transactionsStubs.getLedgerTransactionsFailure(
-          {
-            account_id: gatewayAccountId,
-            limit_total: 'true',
-            limit_total_size: '5001',
-            from_date: '2018-05-03T00:00:00.000Z',
-            to_date: '2023-05-03T00:00:01.000Z',
-            page: '1',
-            display_size: '100'
-          },
-          504)
-      ])
+        // Ensure that transaction list is not displayed
+        cy.get('#transactions-list tbody').should('not.exist')
 
-      // Click the filter button
-      cy.get('#filter').click()
+        // Ensure an error message header is displayed
+        cy.get('h1').contains('An error occurred')
 
-      // Ensure that transaction list is not displayed
-      cy.get('#transactions-list tbody').should('not.exist')
+        // Ensure a generic error message is displayed
+        cy.get('#errorMsg').contains('There is a problem with the payments platform. Please contact the support team.')
+      })
 
-      // Ensure an error message header is displayed
-      cy.get('h1').contains('An error occurred')
+      it('should display the gateway timeout error page, if a gateway timeout error occurs while retrieving the list of transactions', () => {
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsSuccess({ gatewayAccountId, transactions: unfilteredTransactions }),
+        ])
 
-      // Ensure a gateway timeout error message is displayed
-      cy.get('#errorMsg').contains('Your request has timed out. Please apply more filters and try again')
+        cy.visit(transactionsUrl, { failOnStatusCode: false })
+
+        // Fill from and to date
+        cy.get('#fromDate').type('03/5/2018')
+        cy.get('#fromTime').type('01:00:00')
+        cy.get('#toDate').type('03/5/2023')
+        cy.get('#toTime').type('01:00:00')
+
+        // 1. Filtering
+        cy.task('clearStubs')
+
+        cy.task('setupStubs', [
+          ...sharedStubs(),
+          transactionsStubs.getLedgerTransactionsFailure(
+            {
+              account_id: gatewayAccountId,
+              limit_total: 'true',
+              limit_total_size: '5001',
+              from_date: '2018-05-03T00:00:00.000Z',
+              to_date: '2023-05-03T00:00:01.000Z',
+              page: '1',
+              display_size: '100',
+            },
+            504
+          ),
+        ])
+
+        // Click the filter button
+        cy.get('#filter').click()
+
+        // Ensure that transaction list is not displayed
+        cy.get('#transactions-list tbody').should('not.exist')
+
+        // Ensure an error message header is displayed
+        cy.get('h1').contains('An error occurred')
+
+        // Ensure a gateway timeout error message is displayed
+        cy.get('#errorMsg').contains('Your request has timed out. Please apply more filters and try again')
+      })
     })
   })
 })

--- a/test/fixtures/gateway-account/gateway-account.fixture.ts
+++ b/test/fixtures/gateway-account/gateway-account.fixture.ts
@@ -30,7 +30,7 @@ export class GatewayAccountFixture {
   readonly worldpay3dsFlex?: Worldpay3dsFlexCredentialFixture
   readonly sendPayerEmailToGateway: boolean
   readonly sendPayerIPAddressToGateway: boolean
-  readonly serviceId?: string
+  readonly serviceId: string
   readonly serviceName: string
 
   constructor(...overrides: Partial<GatewayAccountFixture>[]) {
@@ -56,7 +56,8 @@ export class GatewayAccountFixture {
     this.supports3ds = false
     this.sendPayerEmailToGateway = false
     this.sendPayerIPAddressToGateway = false
-    this.serviceName = 'A test service'
+    this.serviceId = 'service-external-id-123-abc'
+    this.serviceName = 'Power Plant Safety Inspection'
 
     overrides.forEach((override) => {
       Object.assign(this, override)


### PR DESCRIPTION
## What

PP-15526

When the `transactions` feature flag is enabled, redirect any old transactions pages to the new ones

All Cypress tests for the old transactions pages are skipped, as these routes are no longer accessible. New tests are added to test the redirects.