### PR TITLE
PP-15481 Polyfill service ID for All Service Transaction links if missing

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -66,7 +66,10 @@ async function get(
   }
 
   results.transactions.forEach((transaction) => {
-    transaction._locals.links.bind(transaction.serviceExternalId, req.viewMode.modeName)
+    transaction._locals.links.bind(
+      transaction.serviceExternalId ?? serviceIdPolyfill(transaction.gatewayAccountId, req.viewMode),
+      req.viewMode.modeName
+    )
     transaction._locals.links.bindToAllServices()
   })
 
@@ -124,6 +127,17 @@ async function get(
     transactionCountWithinRange,
     maxTransactions: LEDGER_TRANSACTION_COUNT_LIMIT,
   })
+}
+
+// some old transactions have no `service_id` field - this attempts to polyfill it from the gateway account
+function serviceIdPolyfill(accountId: string, viewMode: ViewMode): string {
+  const gatewayAccount = viewMode.gatewayAccounts.get(`${accountId}`)
+  if (!gatewayAccount) {
+    throw new Error(
+      `Unable to determine service external ID from gateway account [${accountId}]. Gateway account is not attached to request.`
+    )
+  }
+  return gatewayAccount.serviceId!
 }
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {

--- a/src/models/transaction/Transaction.class.ts
+++ b/src/models/transaction/Transaction.class.ts
@@ -22,7 +22,7 @@ import { PaymentDetails } from '@models/transaction/PaymentDetails.class'
 class Transaction {
   // INFO: this is not a complete class yet, see TransactionData interface
   readonly gatewayAccountId: string
-  readonly serviceExternalId: string
+  readonly serviceExternalId?: string
   readonly externalId: string
   readonly gatewayTransactionId: string
   readonly reference: string

--- a/src/models/transaction/dto/Transaction.dto.ts
+++ b/src/models/transaction/dto/Transaction.dto.ts
@@ -8,7 +8,7 @@ import { PaymentDetailsData } from '@models/transaction/dto/PaymentDetails.dto'
 
 export interface TransactionData {
   gateway_account_id: string
-  service_id: string
+  service_id?: string
   credential_external_id: string
   amount: number
   net_amount?: number

--- a/src/models/view-mode/ViewMode.class.ts
+++ b/src/models/view-mode/ViewMode.class.ts
@@ -2,6 +2,7 @@ import PaymentProviders from '@models/constants/payment-providers'
 import User from '@models/user/User.class'
 import { findGatewayAccountsByService } from '@services/gateway-accounts.service'
 import { ViewModeLinksGenerator } from '@models/view-mode/ViewModeLinksGenerator.class'
+import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
 
 export type ViewModeName = 'test' | 'live'
 
@@ -15,6 +16,7 @@ export class ViewMode {
   readonly oppositeModeName: ViewModeName
   readonly hasServicesInOppositeMode: boolean
   readonly gatewayAccountIds: number[]
+  readonly gatewayAccounts: Map<string, GatewayAccount>
   readonly paymentProviders: string[]
   readonly permission?: string
 
@@ -28,6 +30,7 @@ export class ViewMode {
     oppositeModeName: ViewModeName,
     hasServicesInOppositeMode: boolean,
     gatewayAccountIds: number[],
+    gatewayAccounts: Map<string, GatewayAccount>,
     paymentProviders: string[],
     permission?: string
   ) {
@@ -37,6 +40,7 @@ export class ViewMode {
     this.hasServicesInOppositeMode = hasServicesInOppositeMode
 
     this.gatewayAccountIds = gatewayAccountIds
+    this.gatewayAccounts = gatewayAccounts
     this.paymentProviders = paymentProviders
     this.permission = permission
 
@@ -56,12 +60,14 @@ export class ViewMode {
       .map((serviceRole) => serviceRole.service)
       .map((service) => service.externalId)
     if (!userServiceExternalIds.length) {
-      return new ViewMode(modeFilter, false, oppositeModeNames[modeFilter], false, [], [], permission)
+      return new ViewMode(modeFilter, false, oppositeModeNames[modeFilter], false, [], new Map(), [], permission)
     }
 
     const allGatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds)
     const gatewayAccountsForMode = allGatewayAccounts.filter((gatewayAccount) => gatewayAccount.type === modeFilter)
     const gatewayAccountIdsForMode = gatewayAccountsForMode.map((gatewayAccountData) => gatewayAccountData.id)
+
+    const gatewayAccounts = new Map(allGatewayAccounts.map((account) => [`${account.id}`, account]))
 
     const hasServicesInMode = gatewayAccountIdsForMode.length !== 0
     const hasServicesInOppositeMode = allGatewayAccounts.length > gatewayAccountsForMode.length
@@ -76,6 +82,7 @@ export class ViewMode {
       oppositeModeNames[modeFilter],
       hasServicesInOppositeMode,
       gatewayAccountIdsForMode,
+      gatewayAccounts,
       paymentProviders,
       permission
     )

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-index.cy.ts
@@ -2,10 +2,11 @@ import userStubs from '@test/cypress/stubs/user-stubs'
 import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/gateway-account-stubs'
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
-import { getTransactionForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
-import transactionStubs from '@test/cypress/stubs/transaction-stubs'
+import {
+  getTransactionForGatewayAccount,
+  getTransactionsForGatewayAccount,
+} from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import { DateTime } from 'luxon'
-import { TimeConstants } from '@utils/time/time-constants'
 
 const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
 const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
@@ -42,27 +43,9 @@ describe('All service transactions index', () => {
   })
 
   describe('Live page content', () => {
-    beforeEach(() => {
-      cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
-      ])
-    })
-
     it('accessibility check', () => {
       cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
@@ -75,13 +58,7 @@ describe('All service transactions index', () => {
 
     it('should display correct page title and heading', () => {
       cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
@@ -98,13 +75,7 @@ describe('All service transactions index', () => {
 
     it('should not show link to test mode if no test accounts exist', () => {
       cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE],
@@ -118,13 +89,8 @@ describe('All service transactions index', () => {
 
     it('should navigate to test transactions', () => {
       cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        getTransactionsForGatewayAccount(TEST_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           type: TEST,
@@ -154,13 +120,7 @@ describe('All service transactions index', () => {
           gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
           serviceName: SERVICE_NAME,
         }),
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(TEST_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           type: TEST,
@@ -212,13 +172,7 @@ describe('All service transactions index', () => {
 
     it('should navigate to live transactions', () => {
       cy.task('setupStubs', [
-        transactionStubs.getLedgerTransactionsSuccess({
-          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
-          transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-          displaySize: 20,
-          transactionLength: 1,
-        }),
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
         gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
           serviceExternalId: SERVICE_EXTERNAL_ID,
           types: [LIVE, TEST],


### PR DESCRIPTION
## What

PP-15481

Old transactions may not have a `service_id` present in the Ledger database, so `service_id` may be `undefined` in some cases. It therefore cannot be used to create links to transactions, which is done in the All Service Transactions list, as the service ID must be known, since transactions cannot be searched by transaction ID alone. 

This adds a polyfill for determining the service ID from the relevant gateway account if the service ID is missing on the transaction.