### PR TITLE
PP-15481 Fix no results text, ensure permissions for CSV download

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -278,42 +278,42 @@
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 95
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 101
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "a231af987e0851a56413194a38d46620281846c9",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/home/all-service-transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 124
       }
     ],
     "src/views/simplified-account/home/all-service-transactions/nosearch.njk": [
@@ -366,42 +366,42 @@
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "8a764e7de8baf91c09a0141c9d0653d6c62300fa",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "c15bfbed4cf339878d4c69339491df034b592627",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "a231af987e0851a56413194a38d46620281846c9",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "d9d993cc5556aa0fa6e18b26fdfd4fa8527db044",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "ce50854e96f8dd430451450f2e7334e4b48db7f0",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 124
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/views/simplified-account/transactions/index.njk",
         "hashed_secret": "34f47d2f3c482850fd7f6de8564a8aa73afe87bc",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 129
       }
     ],
     "src/views/transactions/index.njk": [
@@ -882,5 +882,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-25T10:14:46Z"
+  "generated_at": "2026-06-29T16:33:07Z"
 }

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.test.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.test.ts
@@ -7,6 +7,9 @@ import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixtu
 import { TransactionStateFixture } from '@test/fixtures/transaction/transaction-state.fixture'
 import { CardDetailsFixture } from '@test/fixtures/card-details/card-details.fixture'
 import { PaginationResult } from '@utils/simplified-account/pagination'
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceRoleFixture } from '@test/fixtures/user/service-role.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const TRANSACTION_EXTERNAL_ID = 'transaction123abc'
@@ -18,6 +21,14 @@ const METADATA_VALUE = 'order-5678'
 const CARD_BRAND = 'visa'
 const REFERENCE = 'REF 123'
 const NOW_DATE_TIME = '2025-11-02T11:47:32.980Z'
+
+const user = new UserFixture({
+  serviceRoles: [
+    new ServiceRoleFixture({
+      service: new ServiceFixture({ externalId: SERVICE_EXTERNAL_ID }),
+    }),
+  ],
+}).toUser()
 
 const transaction = new TransactionFixture({
   gatewayAccountId: GATEWAY_ACCOUNT_ID,
@@ -64,6 +75,7 @@ const { nextRequest, call } = new ControllerTestBuilder(
     '@services/transactions.service': mockLedgerService,
     '@services/card-types.service': mockCardTypesService,
   })
+  .withUser(user)
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
   .withAccount({
     id: GATEWAY_ACCOUNT_ID,

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -13,7 +13,6 @@ import {
   WorldpayStatusFilters,
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { LEDGER_TRANSACTION_COUNT_LIMIT, MAX_TRANSACTIONS_PER_PAGE } from './constants'
-import UserPermissions from '@models/user/permissions'
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {
   const getPath = (pageNumber: number) => {

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -13,6 +13,7 @@ import {
   WorldpayStatusFilters,
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { LEDGER_TRANSACTION_COUNT_LIMIT, MAX_TRANSACTIONS_PER_PAGE } from './constants'
+import UserPermissions from '@models/user/permissions'
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {
   const getPath = (pageNumber: number) => {
@@ -76,7 +77,9 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 
-  const showCsvDownload = transactionCountWithinRange || transactionSearchParams.isRefinedSearch()
+  const showCsvDownload =
+    req.user.hasPermission(req.service.externalId, 'transactions-download:read') &&
+    (transactionCountWithinRange || transactionSearchParams.isRefinedSearch())
 
   req.session.transactionFilters = req.url.split('?')[1] || ''
 

--- a/src/views/simplified-account/home/all-service-transactions/index.njk
+++ b/src/views/simplified-account/home/all-service-transactions/index.njk
@@ -83,24 +83,8 @@
           </div>
         </details>
       {% endif %}
+      {% include "simplified-account/transactions/list.njk" %}
     </div>
-
-    {% if (hasResults) %}
-      {% if (showCsvDownload) %}
-        <p id="csv-download" class="govuk-body">
-          <a
-            href="{{ downloadTransactionLink }}"
-            id="download-transactions-link"
-            class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16"
-          >
-            Download all transaction details as a CSV file
-          </a>
-        </p>
-      {% else %}
-        <p id="csv-download" class="govuk-body">Filter results to download a CSV of transactions</p>
-      {% endif %}
-    {% endif %}
-    {% include "simplified-account/transactions/list.njk" %}
   </div>
 {% endblock %}
 

--- a/src/views/simplified-account/transactions/index.njk
+++ b/src/views/simplified-account/transactions/index.njk
@@ -89,25 +89,6 @@
         </div>
       </details>
     {% endif %}
-
-    {% if permissions.transactions_download_read %}
-
-      {% if (hasResults) %}
-        {% if (showCsvDownload) %}
-          <p id="csv-download" class="govuk-body">
-            <a
-              href="{{ downloadTransactionLink }}"
-              id="download-transactions-link"
-              class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16"
-            >
-              Download all transaction details as a CSV file
-            </a>
-          </p>
-        {% else %}
-          <p id="csv-download" class="govuk-body">Filter results to download a CSV of transactions</p>
-        {% endif %}
-      {% endif %}
-    {% endif %}
     {% include "./list.njk" %}
   </div>
 {% endblock %}

--- a/test/fixtures/user/user.fixture.ts
+++ b/test/fixtures/user/user.fixture.ts
@@ -16,7 +16,7 @@ export class UserFixture {
   readonly internalUser: boolean
   readonly numberOfLiveServices: number
 
-  constructor(overrides?: Partial<UserData>) {
+  constructor(overrides?: Partial<UserFixture>) {
     this.externalId = 'user-123-external-id'
     this.email = 'homer.simpson@example.com'
     this.serviceRoles = [new ServiceRoleFixture()]


### PR DESCRIPTION
## What

PP-15481

- Fix "There are no results for the filters you used." text showing next to filters on All Service Transactions search page
  - this now shows under the search menu, as intended
- Add permission check for CSV download
  - in practice, all roles have this permission, however this check is important should this change in the future
- Remove some code in Transaction and All Service Transaction list templates which was erroneously copied from old pages

### Screenshots (views have been added/changed)
<img width="1269" height="783" alt="Screenshot 2026-06-29 at 17 36 23" src="https://github.com/user-attachments/assets/6bb9b1ef-ac41-4193-b18c-c49e649b8e49" />
