### PR TITLE
PP-15481 Fix CSV download link on payouts page & modify default Transactions search

### DIFF
--- a/src/controllers/payouts/payout-list.controller.js
+++ b/src/controllers/payouts/payout-list.controller.js
@@ -4,6 +4,9 @@ const { response } = require('../../utils/response')
 const permissions = require('../../utils/permissions')
 const payoutService = require('./payouts.service')
 const { NoServicesWithPermissionError } = require('../../errors')
+const { Features } = require('@root/config/features')
+const paths = require('@root/paths')
+const formatPathFor = require('@utils/replace-params-in-path')
 
 const listAllServicesPayouts = async function listAllServicesPayouts(req, res, next) {
   const { page } = req.query
@@ -52,6 +55,9 @@ const listAllServicesPayouts = async function listAllServicesPayouts(req, res, n
       filterLiveAccounts,
       hasLiveAccounts: userPermittedAccountsSummary.hasLiveAccounts,
       hasTestStripeAccount: userPermittedAccountsSummary.hasTestStripeAccount,
+      transactionsDownloadPath: Features.isEnabled(Features.TRANSACTIONS)
+        ? formatPathFor(paths.allServiceTransactions.simplifiedAccount.download, filterLiveAccounts ? 'live' : 'test')
+        : formatPathFor(paths.allServiceTransactions.downloadStatusFilter, filterLiveAccounts ? 'live' : 'test'),
     })
   } catch (error) {
     return next(new Error('Failed to fetch payouts'))

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -22,6 +22,7 @@ import {
   LEDGER_TRANSACTION_COUNT_LIMIT,
   MAX_TRANSACTIONS_PER_PAGE,
 } from '@controllers/simplified-account/services/transactions/constants'
+import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
 
 async function get(
   req: AuthenticatedRequest & { viewMode: ViewMode },
@@ -49,7 +50,7 @@ async function get(
     req.query,
     true,
     MAX_TRANSACTIONS_PER_PAGE
-  )
+  ).withDefaultDateFilter(Period.LAST_12_MONTHS)
 
   let cardTypes: CardType[]
   let results: TransactionSearchResults

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -13,6 +13,7 @@ import {
   WorldpayStatusFilters,
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { LEDGER_TRANSACTION_COUNT_LIMIT, MAX_TRANSACTIONS_PER_PAGE } from './constants'
+import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {
   const getPath = (pageNumber: number) => {
@@ -32,7 +33,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
     req.query,
     true,
     MAX_TRANSACTIONS_PER_PAGE
-  )
+  ).withDefaultDateFilter(Period.LAST_12_MONTHS)
 
   const transactionsUrl = formatServiceAndAccountPathsFor(
     paths.simplifiedAccount.transactions.index,

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -65,6 +65,11 @@ export class TransactionSearchParams {
   constructor(gatewayAccountIds: number[] | string[], withPagintion: boolean) {
     this.accountIds = gatewayAccountIds
     this.withPagination = withPagintion
+
+    if (withPagintion) {
+      this.limitTotal = true
+      this.limitTotalSize = 5001
+    }
   }
 
   toJson() {
@@ -107,6 +112,17 @@ export class TransactionSearchParams {
     filters.delete('page')
     filters.delete('jsEnabled')
     return filters.size === 1 && filters.get('dateFilter') === Period.ALL_TIME
+  }
+
+  withDefaultDateFilter(dateFilter: Period) {
+    if (!this.dateFilter && !this.fromDate && !this.toDate) {
+      const dateRange = getPeriodUKDateTimeRange(dateFilter)
+      this.dateFilter = dateFilter
+      this.fromDate = dateRange.start
+      this.toDate = dateRange.end
+      this.includeTime = false
+    }
+    return this
   }
 
   static forAgreement(gatewayAccountId: number, agreementExternalId: string, currentPage: number, displaySize: number) {

--- a/src/models/transaction/TransactionSearchParams.test.ts
+++ b/src/models/transaction/TransactionSearchParams.test.ts
@@ -1,0 +1,18 @@
+import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
+
+describe('Transaction search params tests', () => {
+  it('should produce correct query params when only a gatewayPayoutId is provided', () => {
+    const testGatewayAccountIds = ['1', '2', '3']
+
+    const searchParams = TransactionSearchParams.fromSearchQuery(
+      testGatewayAccountIds,
+      {
+        gatewayPayoutId: 'gateway-payout-id-abc-123',
+      },
+      false
+    )
+
+    const queryString = searchParams.toJson().asQueryString()
+    queryString.should.eq('account_id=1%2C2%2C3&gateway_payout_id=gateway-payout-id-abc-123')
+  })
+})

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -1,6 +1,5 @@
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
 import { toLower } from 'lodash'
-import { TimeConstants } from '@utils/time/time-constants'
 
 export class TransactionSearchParamsData {
   readonly account_id: string

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -5,8 +5,8 @@ import { TimeConstants } from '@utils/time/time-constants'
 export class TransactionSearchParamsData {
   readonly account_id: string
   readonly agreement_id?: string
-  readonly limit_total: string
-  readonly limit_total_size: string
+  readonly limit_total?: boolean
+  readonly limit_total_size?: string
   readonly display_size?: string
   readonly page?: string
   readonly cardholder_name?: string
@@ -26,8 +26,8 @@ export class TransactionSearchParamsData {
   constructor(params: TransactionSearchParams) {
     this.account_id = params.accountIds.join(',')
     this.agreement_id = params.agreementId?.toString() ?? undefined
-    this.limit_total = params.limitTotal ? params.limitTotal.toString() : 'true'
-    this.limit_total_size = params.limitTotalSize?.toString() ?? '5001'
+    this.limit_total = params.limitTotal ?? undefined
+    this.limit_total_size = params.limitTotalSize?.toString() ?? undefined
     this.display_size = params.displaySize?.toString() ?? undefined
     this.page = params.page?.toString()
     this.cardholder_name = params.cardholderName?.toString() ?? undefined
@@ -37,22 +37,12 @@ export class TransactionSearchParamsData {
     this.transaction_type = params.type ?? undefined
     this.reference = params.reference ?? undefined
     this.email = params.email ?? undefined
-    this.from_date = this.setFromDate(params) ?? undefined
+    this.from_date = params.fromDate?.isValid ? params.fromDate.toUTC().toISO() : undefined
     this.to_date = params.toDate?.isValid ? params.toDate.toUTC().toISO() : undefined
     this.payment_states = params.paymentStates?.map(toLower).join(',')
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')
     this.gateway_payout_id = params.gatewayPayoutId
-  }
-
-  setFromDate(params: TransactionSearchParams) {
-    if (params.dateFilter === 'all-time') {
-      return undefined
-    } else if (params.fromDate?.isValid) {
-      return params.fromDate.toUTC().toISO()
-    } else {
-      return TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO()
-    }
   }
 
   asQueryString(): string {

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.test.ts
@@ -34,11 +34,11 @@ describe('DateTime Utility', () => {
 
   describe('getPeriodUKDateTimeRange', () => {
     describe('when period is "today"', () => {
-      it('should return range from start of today to current time', () => {
+      it('should return range from start of today to the end of the day', () => {
         const result = getPeriodUKDateTimeRange('today')
 
         const expectedStart = DateTime.fromISO('2025-01-15T00:00:00.000', { zone: 'Europe/London' })
-        const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000', { zone: 'Europe/London' })
+        const expectedEnd = DateTime.fromISO('2025-01-15T23:59:59.999', { zone: 'Europe/London' })
 
         expect(result.start!.toISO()).to.equal(expectedStart.toISO())
         expect(result.end!.toISO()).to.equal(expectedEnd.toISO())
@@ -107,11 +107,11 @@ describe('DateTime Utility', () => {
     })
 
     describe('when period is "last-12-months"', () => {
-      it('should return range for 12 months ending now', () => {
+      it('should return range for 12 months ending at the end of the day', () => {
         const result = getPeriodUKDateTimeRange('last-12-months')
 
         const expectedStart = DateTime.fromISO('2024-01-15T00:00:00.000', { zone: 'Europe/London' })
-        const expectedEnd = DateTime.fromISO('2025-01-15T14:30:00.000Z', { zone: 'Europe/London' })
+        const expectedEnd = DateTime.fromISO('2025-01-15T23:59:59.999Z', { zone: 'Europe/London' })
 
         expect(result.start!.toISO()).to.equal(expectedStart.toISO())
         expect(result.end!.toISO()).to.equal(expectedEnd.toISO())

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -76,7 +76,7 @@ export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRa
     case 'last-12-months': {
       return {
         start: TimeConstants.TWELVE_MONTHS_AGO,
-        end: now,
+        end: TimeConstants.END_OF_TODAY,
       }
     }
 
@@ -90,8 +90,8 @@ export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRa
     default:
       // today
       return {
-        start: now.startOf('day'),
-        end: now,
+        start: TimeConstants.TODAY,
+        end: TimeConstants.END_OF_TODAY,
       }
   }
 }

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -45,8 +45,6 @@ export const DT_FULL = {
 } as DateTimeFormatOptions
 
 export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRange {
-  const now = DateTime.now().setLocale('en-GB').setZone('Europe/London') as DateTime<true>
-
   switch (period) {
     case 'yesterday':
       return {

--- a/src/views/payouts/list.njk
+++ b/src/views/payouts/list.njk
@@ -2,97 +2,73 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-Payments to your bank account - GOV.UK Pay
+  Payments to your bank account - GOV.UK Pay
 {% endblock %}
 
 {% block beforeContent %}
   {% set pageTitleBreadcrumbWithTag %}
-      <span>Payments to your bank account</span>
-      <strong class="govuk-tag govuk-tag--grey service-info--tag">{{ "Live" if filterLiveAccounts else "Test" }}</strong>
+    <span>Payments to your bank account</span>
+    <strong class="govuk-tag govuk-tag--grey service-info--tag">{{ "Live" if filterLiveAccounts else "Test" }}</strong>
   {% endset %}
-  {{ breadcrumbs([
-    { text: "My services", href: routes.services.index },
-    { html: pageTitleBreadcrumbWithTag  }
-  ]) }}
+  {{
+    breadcrumbs([
+      { text: "My services", href: routes.services.index },
+      { html: pageTitleBreadcrumbWithTag  }
+    ])
+  }}
 {% endblock %}
 
 {% block mainContent %}
-<div class="govuk-grid-column-full">
-  <h1 class="govuk-heading-l">
-    Payments to your bank account
-    <strong class="govuk-tag govuk-tag--grey">{{ "Live" if filterLiveAccounts else "Test" }}</strong>
-  </h1>
-</div>
-<div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-0">
-  <p class="govuk-body">Payments Stripe has made to your bank account.</p>
-  {% if not filterLiveAccounts %}
-    <div class="govuk-inset-text">
-    <p class="govuk-body">Test reports represent how payments to your bank account appear. They show the total amount received from Stripe in each payment and detail all the transactions.</p>
-    <p class="govuk-body">The reports are available the next working day after your test transactions. With test transactions, no payments are made to your bank account.</p>
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      Payments to your bank account
+      <strong class="govuk-tag govuk-tag--grey">{{ "Live" if filterLiveAccounts else "Test" }}</strong>
+    </h1>
+  </div>
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-0">
+    <p class="govuk-body">Payments Stripe has made to your bank account.</p>
+    {% if not filterLiveAccounts %}
+      <div class="govuk-inset-text">
+        <p class="govuk-body"
+          >Test reports represent how payments to your bank account appear. They show the total amount received from
+          Stripe in each payment and detail all the transactions.</p
+        >
+        <p class="govuk-body"
+          >The reports are available the next working day after your test transactions. With test transactions, no
+          payments are made to your bank account.</p
+        >
 
-    <p class="govuk-body">Once your service is live, you should receive payments to your bank account within:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>2 working days if your user completed their payment during the week</li>
-      <li>3 working days if your user completed their payment at the weekend or on a bank holiday</li>
-    </ul>
-    </div>
-  {% endif %}
-
-  <p class="govuk-body">
-    {% if filterLiveAccounts %}
-      {% if hasTestStripeAccount %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') }}">Switch to test transactions</a>
-      {% endif %}
-    {% else %}
-      {% if hasLiveAccounts %}
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.payouts.list }}">Switch to live transactions</a>
-      {% endif %}
+        <p class="govuk-body">Once your service is live, you should receive payments to your bank account within:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>2 working days if your user completed their payment during the week</li>
+          <li>3 working days if your user completed their payment at the weekend or on a bank holiday</li>
+        </ul>
+      </div>
     {% endif %}
-  </p>
-</div>
 
-{% set transactionsDownloadPath = routes.allServiceTransactions.download if filterLiveAccounts else routes.formattedPathFor(routes.allServiceTransactions.downloadStatusFilter, 'test') %}
-<div class="govuk-grid-column-two-thirds">
-  {% for key, group in payoutSearchResult.groups %}
-    {% set dateString = group.date.format('D MMMM YYYY') %}
-    <h2 class="govuk-heading-m" data-cy="payout-date">{{ dateString }}</h2>
-
-    <table class="govuk-table" id="payout-list">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Service</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Amount</th>
-          <th scope="col" class="govuk-table__header">View transactions</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        {% for payoutEntry in group.entries %}
-        <tr class="govuk-table__row">
-          <td scope="row" class="govuk-table__cell">{{ payoutEntry.serviceName }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            {{ payoutEntry.amount | penceToPoundsWithCurrency }}
-          </td>
-          <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ transactionsDownloadPath }}?gatewayPayoutId={{payoutEntry.gateway_payout_id}}">
-              Download CSV <span class="govuk-visually-hidden">for {{ payoutEntry.serviceName }} on {{ dateString }}</span>
-            </a>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% else %}
-    {% if filterLiveAccounts %}
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      {% if payoutsReleaseDate %}
-        <p class="govuk-body">No payments to your bank account found on or after {{ payoutsReleaseDate.format('D MMMM YYYY') }}.</p>
-        <p class="govuk-body">For historic payments to your bank account please <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact support.</a></p>
+    <p class="govuk-body">
+      {% if filterLiveAccounts %}
+        {% if hasTestStripeAccount %}
+          <a
+            class="govuk-link govuk-link--no-visited-state"
+            href="{{ routes.formattedPathFor(routes.payouts.listStatusFilter, 'test') }}"
+            >Switch to test transactions</a
+          >
+        {% endif %}
       {% else %}
-        <p class="govuk-body">No payments to your bank account found.</p>
+        {% if hasLiveAccounts %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ routes.payouts.list }}"
+            >Switch to live transactions</a
+          >
+        {% endif %}
       {% endif %}
-    {% else %}
-      <h2 class="govuk-heading-m">Sample Report</h2>
-      <p class="govuk-body">This is a sample report. If you make test payments, you’ll be able to see a copy of the report using your test payments.</p>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    {% for key, group in payoutSearchResult.groups %}
+      {% set dateString = group.date.format('D MMMM YYYY') %}
+      <h2 class="govuk-heading-m" data-cy="payout-date">{{ dateString }}</h2>
 
       <table class="govuk-table" id="payout-list">
         <thead class="govuk-table__head">
@@ -103,25 +79,69 @@ Payments to your bank account - GOV.UK Pay
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">Test Service</td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
-              {{ 19402 | penceToPoundsWithCurrency }}
-            </td>
-            <td class="govuk-table__cell">
-              <a class="govuk-link govuk-link--no-visited-state" href="/assets/csv/sample_reporting_payout.csv">
-                Download CSV
-              </a>
-            </td>
-          </tr>
+          {% for payoutEntry in group.entries %}
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">{{ payoutEntry.serviceName }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                {{ payoutEntry.amount | penceToPoundsWithCurrency }}
+              </td>
+              <td class="govuk-table__cell">
+                <a
+                  class="govuk-link govuk-link--no-visited-state"
+                  href="{{ transactionsDownloadPath }}?gatewayPayoutId={{ payoutEntry.gateway_payout_id }}"
+                >
+                  Download CSV
+                  <span class="govuk-visually-hidden">for {{ payoutEntry.serviceName }} on {{ dateString }}</span>
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
         </tbody>
       </table>
-    {% endif %}
-  {% endfor %}
-</div>
+    {% else %}
+      {% if filterLiveAccounts %}
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+        {% if payoutsReleaseDate %}
+          <p class="govuk-body"
+            >No payments to your bank account found on or after {{ payoutsReleaseDate.format('D MMMM YYYY') }}.</p
+          >
+          <p class="govuk-body"
+            >For historic payments to your bank account please
+            <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact support.</a></p
+          >
+        {% else %}
+          <p class="govuk-body">No payments to your bank account found.</p>
+        {% endif %}
+      {% else %}
+        <h2 class="govuk-heading-m">Sample Report</h2>
+        <p class="govuk-body"
+          >This is a sample report. If you make test payments, you’ll be able to see a copy of the report using your
+          test payments.</p
+        >
 
-<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
-  {% include "payouts/paginator.njk" %}
-</div>
+        <table class="govuk-table" id="payout-list">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Service</th>
+              <th scope="col" class="govuk-table__header govuk-table__header--numeric">Amount</th>
+              <th scope="col" class="govuk-table__header">View transactions</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">Test Service</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"> {{ 19402 | penceToPoundsWithCurrency }} </td>
+              <td class="govuk-table__cell">
+                <a class="govuk-link govuk-link--no-visited-state" href="/assets/csv/sample_reporting_payout.csv">
+                  Download CSV
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      {% endif %}
+    {% endfor %}
+  </div>
 
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4"> {% include "payouts/paginator.njk" %} </div>
 {% endblock %}

--- a/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
+++ b/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
@@ -42,7 +42,10 @@ const setupStubs = (options = {}) => {
     transactionStubs.getLedgerTransactionsSuccess({
       gatewayAccountId: GATEWAY_ACCOUNT_ID,
       displaySize: 20,
-      filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+      filters: {
+        from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+        to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+      },
       transactionLength: 1,
     }),
     gatewayAccountStubs.getCardTypesSuccess(),

--- a/test/cypress/integration/payouts/payouts-list.cy.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.js
@@ -32,7 +32,7 @@ describe('Payout list page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it.only('should correctly display payouts given a successful response from Ledger', () => {
+  it('should correctly display payouts given a successful response from Ledger', () => {
     const payouts = [
       {
         gatewayAccountId: liveGatewayAccountId,

--- a/test/cypress/integration/payouts/payouts-list.cy.js
+++ b/test/cypress/integration/payouts/payouts-list.cy.js
@@ -11,20 +11,20 @@ const userAndGatewayAccountStubs = [
     userExternalId,
     gatewayAccountIds: [liveGatewayAccountId, testGatewayAccountId],
     serviceName: 'some-service-name',
-    email: 'some-user@email.com'
+    email: 'some-user@email.com',
   }),
   gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
     {
       gatewayAccountId: liveGatewayAccountId,
       paymentProvider: 'stripe',
-      type: 'live'
+      type: 'live',
     },
     {
       gatewayAccountId: testGatewayAccountId,
       paymentProvider: 'stripe',
-      type: 'test'
-    }
-  ])
+      type: 'test',
+    },
+  ]),
 ]
 
 describe('Payout list page', () => {
@@ -32,13 +32,17 @@ describe('Payout list page', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  it('should correctly display payouts given a successful response from Ledger', () => {
+  it.only('should correctly display payouts given a successful response from Ledger', () => {
     const payouts = [
-      { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2024-12-31T15:34:00.000000Z' }
+      {
+        gatewayAccountId: liveGatewayAccountId,
+        paidOutDate: '2024-12-31T15:34:00.000000Z',
+        gatewayPayoutId: 'payout-id-abc-123',
+      },
     ]
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId, payouts })
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId, payouts }),
     ])
 
     cy.visit('/payments-to-your-bank-account')
@@ -52,17 +56,41 @@ describe('Payout list page', () => {
       cy.get('.govuk-breadcrumbs__list-item').eq(1).contains('Payments to your bank account')
       cy.get('.govuk-breadcrumbs__list-item').eq(1).find('.govuk-tag').should('have.text', 'Live')
     })
+
+    cy.get('table#payout-list').within(() => {
+      cy.get('thead > tr').within(() => {
+        cy.get('th').eq(0).should('contain.text', 'Service')
+        cy.get('th').eq(1).should('contain.text', 'Amount')
+        cy.get('th').eq(2).should('contain.text', 'View transactions')
+      })
+
+      cy.get('tbody > tr')
+        .eq(0)
+        .within(() => {
+          cy.get('td').eq(0).should('contain.text', 'some-service-name')
+          cy.get('td').eq(1).should('contain.text', '£100.00')
+          cy.get('td')
+            .eq(2)
+            .should('contain.text', 'Download CSV')
+            .get('a')
+            .should('have.attr', 'href', `/transactions/live/download?gatewayPayoutId=payout-id-abc-123`)
+        })
+    })
   })
 
   it('pagination component should correctly link for a large set', () => {
     const payouts = [
       { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2019-01-28T08:00:00.000000Z' },
-      { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2019-01-28T08:00:00.000000Z' }
+      { gatewayAccountId: liveGatewayAccountId, paidOutDate: '2019-01-28T08:00:00.000000Z' },
     ]
     const page = 2
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId, payouts, payoutOpts: { total: 80, page } })
+      payoutStubs.getLedgerPayoutSuccess({
+        gatewayAccountId: liveGatewayAccountId,
+        payouts,
+        payoutOpts: { total: 80, page },
+      }),
     ])
 
     cy.visit(`/payments-to-your-bank-account?page=${page}`)
@@ -75,13 +103,11 @@ describe('Payout list page', () => {
   })
 
   it('should show test payouts when Switch to test is clicked', () => {
-    const testPayouts = [
-      { gatewayAccountId: testGatewayAccountId, paidOutDate: '2019-01-29T08:00:00.000000Z' }
-    ]
+    const testPayouts = [{ gatewayAccountId: testGatewayAccountId, paidOutDate: '2019-01-29T08:00:00.000000Z' }]
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId, payouts: [] }),
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: testGatewayAccountId, payouts: testPayouts })
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: testGatewayAccountId, payouts: testPayouts }),
     ])
     cy.visit('/payments-to-your-bank-account')
 
@@ -101,7 +127,7 @@ describe('Payout list page', () => {
   it('should show sample report for test account account if the test account has no payouts', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: testGatewayAccountId })
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: testGatewayAccountId }),
     ])
 
     cy.visit('/payments-to-your-bank-account/test')
@@ -119,14 +145,16 @@ describe('Payout list page', () => {
   it('should show no payouts for live account if the live account has no payouts', () => {
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
-      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId })
+      payoutStubs.getLedgerPayoutSuccess({ gatewayAccountId: liveGatewayAccountId }),
     ])
 
     cy.visit('/payments-to-your-bank-account')
     cy.get('h1').find('.govuk-tag').should('have.text', 'Live')
     cy.get('#pagination').should('not.exist')
     cy.get('#payout-list').should('not.exist')
-    cy.get('.govuk-section-break.govuk-section-break--l.govuk-section-break--visible').next('p').contains('No payments to your bank account found on or after 22 May 2020')
+    cy.get('.govuk-section-break.govuk-section-break--l.govuk-section-break--visible')
+      .next('p')
+      .contains('No payments to your bank account found on or after 22 May 2020')
   })
 
   it('should show no permissions to access this page if the user has no stripe test accounts', () => {
@@ -135,18 +163,21 @@ describe('Payout list page', () => {
         userExternalId,
         gatewayAccountIds: [testGatewayAccountId],
         serviceName: 'some-service-name',
-        email: 'some-user@email.com'
+        email: 'some-user@email.com',
       }),
       gatewayAccountStubs.getGatewayAccountsSuccessForMultipleAccounts([
         {
           gatewayAccountId: testGatewayAccountId,
           paymentProvider: 'sandbox',
-          type: 'test'
-        }
-      ])
+          type: 'test',
+        },
+      ]),
     ])
 
     cy.visit('/payments-to-your-bank-account/test', { failOnStatusCode: false })
-    cy.get('#errorMsg').should('have.text', 'You do not have any associated services with rights to view payments to bank accounts.')
+    cy.get('#errorMsg').should(
+      'have.text',
+      'You do not have any associated services with rights to view payments to bank accounts.'
+    )
   })
 })

--- a/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
+++ b/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
@@ -7,7 +7,6 @@ import {
   checkServiceNavigation,
   checkTitleAndHeading,
 } from '@test/cypress/integration/simplified-account/common/assertions'
-import { TimeConstants } from '@utils/time/time-constants'
 
 const USER_EXTERNAL_ID = 'user456def'
 const USER_EMAIL = 's.mcduck@pay.gov.uk'
@@ -170,7 +169,6 @@ describe('Agreements', () => {
         filters: {
           agreement_id: 'a-valid-agreement-id',
           display_size: 5,
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
         },
       }),
     ])
@@ -289,7 +287,6 @@ describe('Agreements', () => {
         filters: {
           agreement_id: 'agreement123abc',
           display_size: 5,
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
         },
       }),
       agreementStubs.postCancelAgreementByServiceExternalIdAndAccountType({

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
@@ -78,11 +78,9 @@ describe('All Service Transactions list', () => {
       const accountIds = [TEST_STRIPE_ACCOUNT, TEST_SANDBOX_ACCOUNT, TEST_WORLDPAY_ACCOUNT].map((account) => account.id)
       cy.task('setupStubs', [
         getUser(USER_EXTERNAL_ID).success(userWithStripeService),
-        searchTransactions(TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20)).success([
-          STRIPE_TRANSACTION,
-          WORLDPAY_TRANSACTION,
-          SANDBOX_TRANSACTION,
-        ]),
+        searchTransactions(
+          TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20).withDefaultDateFilter('last-12-months')
+        ).success([STRIPE_TRANSACTION, WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([
           SANDBOX_SERVICE.externalId,
           WORLDPAY_SERVICE.externalId,
@@ -151,10 +149,9 @@ describe('All Service Transactions list', () => {
       const accountIds = [TEST_SANDBOX_ACCOUNT, TEST_WORLDPAY_ACCOUNT].map((account) => account.id)
       cy.task('setupStubs', [
         getUser(USER_EXTERNAL_ID).success(userWithoutStripeService),
-        searchTransactions(TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20)).success([
-          WORLDPAY_TRANSACTION,
-          SANDBOX_TRANSACTION,
-        ]),
+        searchTransactions(
+          TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20).withDefaultDateFilter('last-12-months')
+        ).success([WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([SANDBOX_SERVICE.externalId, WORLDPAY_SERVICE.externalId]).success([
           TEST_SANDBOX_ACCOUNT,
           TEST_WORLDPAY_ACCOUNT,

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -136,7 +136,10 @@ describe('Transactions index', () => {
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
           transactionLength: 6000,
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
         }),
       ])
@@ -155,7 +158,11 @@ describe('Transactions index', () => {
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
           transactionLength: 6000,
-          filters: { reference: 'unfiltered', from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            reference: 'unfiltered',
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
         }),
       ])
@@ -266,10 +273,10 @@ describe('Transactions index', () => {
         .find('th')
         .should('contain', unfilteredTransactions[2].reference)
 
-      cy.get('#fromDate').type('01/01/2025')
+      cy.get('#fromDate').clear().type('01/01/2025')
       cy.get('.datepicker').should('be.visible')
 
-      cy.get('#toDate').type('01/01/2026')
+      cy.get('#toDate').clear().type('01/01/2026')
       cy.get('.datepicker').should('be.visible')
 
       cy.get('.govuk-button').contains('Search transactions').click()
@@ -612,6 +619,7 @@ describe('Transactions index', () => {
             transactions: [TRANSACTION],
             filters: {
               from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+              to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
             },
             displaySize: 20,
             transactionLength: 1,
@@ -642,6 +650,7 @@ describe('Transactions index', () => {
             transactions: [TRANSACTION],
             filters: {
               from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+              to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
             },
             displaySize: 20,
             transactionLength: 1,
@@ -670,7 +679,10 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
           transactionLength: 50,
         }),
@@ -721,7 +733,10 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
           transactionLength: 100,
           page: 3,
@@ -760,7 +775,10 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
           transactionLength: 100,
           page: 5,
@@ -790,7 +808,10 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+          filters: {
+            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
+          },
           displaySize: 20,
           transactionLength: 10,
           page: 1,
@@ -819,6 +840,7 @@ describe('Transactions index', () => {
         transactions: [TRANSACTION],
         filters: {
           from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
           reference,
           email,
           cardholder_name: cardholderNameSearchParam,
@@ -861,6 +883,7 @@ describe('Transactions index', () => {
         transactions: [TRANSACTION],
         filters: {
           from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
         },
         displaySize: 20,
         transactionLength: 6000,
@@ -908,6 +931,7 @@ describe('Transactions index', () => {
         transactions: [TRANSACTION],
         filters: {
           from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
           reference,
           email,
           cardholder_name: cardholderNameSearchParam,

--- a/test/cypress/stubs/simplified-account/transaction-stubs.ts
+++ b/test/cypress/stubs/simplified-account/transaction-stubs.ts
@@ -56,6 +56,7 @@ function getTransactionsForGatewayAccount(gatewayAccountId: string) {
           limit_total: true,
           limit_total_size: 5001,
           from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
+          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
         },
       })
     },


### PR DESCRIPTION
## What

PP-15481

With the old Transactions URLs redirecting to the new ones, the CSV download link in the "Payments to your bank account" does not work, as it does not change to the new Transactions URL with the `transactions` feature flag. This fixes the link to correctly link to the new CSV download URL when the `transactions` feature flag is enabled.

This also modifies the way default Ledger search parameters are set, so that CSV downloads do not add additional search parameters, such as a `from_date` or `limit_total`. These are instead now configured by the controller setting the search parameters.

The `transaction-index` and `all-service-transaction` controllers set a default `from_date` and `to_date` for the `last-12-months` date filter period. This has been amended to make the `to_date` the end of the current day, rather than the current time. This is primarily to make Cypress testing easier, as it is not possible (with the current configuration) to stub the date in the running app used by Cypress. This is not important for the functionality, as Ledger will accept a `to_date` that is in the future. 

The code for `TransactionSearchParams` is a little clunky, and could likely be improved, but this should be left for future work. 