### PR TITLE
PP-15481 Fix missing MOTO and Fee columns in CSV downloads

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transaction-csv-download.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transaction-csv-download.controller.ts
@@ -5,25 +5,15 @@ import { downloadCsv } from '@services/transactions.service'
 import logger from '@utils/logger'
 import PaymentProviders from '@models/constants/payment-providers'
 import date from '@utils/dates'
-import { findGatewayAccountsByService } from '@services/gateway-accounts.service'
+import { ViewMode } from '@models/view-mode/ViewMode.class'
 const LOGGER = logger(__filename)
 
-async function get(req: AuthenticatedRequest, res: express.Response<unknown, { flash?: Record<string, string[]> }>) {
-  const modeFilter = req.params.modeFilter === 'test' ? 'test' : 'live'
-
-  const userServiceExternalIds = req.user.serviceRoles
-    .filter((serviceRole) => serviceRole.hasPermission('transactions-download:read'))
-    .map((serviceRole) => serviceRole.service)
-    .map((service) => service.externalId)
-
-  const gatewayAccounts = await findGatewayAccountsByService(userServiceExternalIds, modeFilter)
-  const gatewayAccountIds = gatewayAccounts.map((gatewayAccountData) => gatewayAccountData.id)
-  const transactionSearchParams = TransactionSearchParams.fromSearchQuery(gatewayAccountIds, req.query, false)
-
-  if (gatewayAccounts.some((gatewayAccount) => gatewayAccount.paymentProvider === PaymentProviders.STRIPE)) {
-    transactionSearchParams.feeHeaders = true
-  }
-  transactionSearchParams.motoHeader = gatewayAccounts.some((gatewayAccount) => gatewayAccount.allowMoto)
+async function get(req: AuthenticatedRequest & { viewMode: ViewMode }, res: express.Response) {
+  const isMoto = Array.from(req.viewMode.gatewayAccounts.values()).some((gatewayAccount) => gatewayAccount.allowMoto)
+  const transactionSearchParams = TransactionSearchParams.Builder(req.viewMode.gatewayAccountIds)
+    .withSearchQuery(req.query)
+    .withMotoHeader(isMoto)
+    .withFeeHeaders(req.viewMode.paymentProviders.includes(PaymentProviders.STRIPE))
 
   const filename = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const [downloadStartTime, downloadEndTime] = await downloadCsv(transactionSearchParams, filename, res)
@@ -41,7 +31,7 @@ async function get(req: AuthenticatedRequest, res: express.Response<unknown, { f
     multiple_accounts: false,
     all_service_transactions: false,
     user_number_of_live_services: req.user.numberOfLiveServices,
-    is_live: modeFilter === 'live',
+    is_live: req.viewMode.modeName === 'live',
     filters: transactionSearchParams.getFilterKeys().join(', '),
   })
 

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -44,13 +44,10 @@ async function get(
   }
 
   const isStripe = req.viewMode.paymentProviders.includes(PaymentProviders.STRIPE)
-
-  const transactionSearchParams = TransactionSearchParams.fromSearchQuery(
-    req.viewMode.gatewayAccountIds,
-    req.query,
-    true,
-    MAX_TRANSACTIONS_PER_PAGE
-  ).withDefaultDateFilter(Period.LAST_12_MONTHS)
+  const transactionSearchParams = TransactionSearchParams.Builder(req.viewMode.gatewayAccountIds)
+    .withDefaultDateFilter(Period.LAST_12_MONTHS)
+    .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+    .withSearchQuery(req.query)
 
   let cardTypes: CardType[]
   let results: TransactionSearchResults

--- a/src/controllers/simplified-account/services/transactions/csv-download/transaction-csv-download.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/csv-download/transaction-csv-download.controller.ts
@@ -7,12 +7,11 @@ import date from '@utils/dates'
 const LOGGER = logger(__filename)
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
-  const gatewayAccountId = req.account.id
-  const transactionSearchParams = TransactionSearchParams.fromSearchQuery(gatewayAccountId, req.query, false)
-  if (req.account && req.account.paymentProvider === PaymentProviders.STRIPE) {
-    transactionSearchParams.feeHeaders = true
-  }
-  transactionSearchParams.motoHeader = req.account.allowMoto
+  const transactionSearchParams = TransactionSearchParams.Builder(req.account.id)
+    .withSearchQuery(req.query)
+    .withMotoHeader(req.account.allowMoto)
+    .withFeeHeaders(req.account.paymentProvider === PaymentProviders.STRIPE)
+
   const filename = `GOVUK_Pay_${date.dateToDefaultFormat(new Date()).replace(' ', '_')}.csv`
   const [downloadStartTime, downloadEndTime] = await downloadCsv(transactionSearchParams, filename, res)
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -28,12 +28,10 @@ const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: strin
 async function get(req: ServiceRequest, res: ServiceResponse) {
   const isStripe = req.account.paymentProvider === 'stripe'
   const gatewayAccountId = req.account.id
-  const transactionSearchParams = TransactionSearchParams.fromSearchQuery(
-    gatewayAccountId,
-    req.query,
-    true,
-    MAX_TRANSACTIONS_PER_PAGE
-  ).withDefaultDateFilter(Period.LAST_12_MONTHS)
+  const transactionSearchParams = TransactionSearchParams.Builder(gatewayAccountId)
+    .withDefaultDateFilter(Period.LAST_12_MONTHS)
+    .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+    .withSearchQuery(req.query)
 
   const transactionsUrl = formatServiceAndAccountPathsFor(
     paths.simplifiedAccount.transactions.index,

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -60,16 +60,84 @@ export class TransactionSearchParams {
   feeHeaders?: boolean
   baseQuery?: TransactionSearchQuery
   includeTime?: boolean
-  withPagination: boolean
+  hasPagination?: boolean
 
-  constructor(gatewayAccountIds: number[] | string[], withPagintion: boolean) {
+  constructor(gatewayAccountIds: number[] | string[]) {
     this.accountIds = gatewayAccountIds
-    this.withPagination = withPagintion
+  }
 
-    if (withPagintion) {
-      this.limitTotal = true
-      this.limitTotalSize = 5001
+  static Builder(gatewayAccountIds: number | number[] | string | string[]) {
+    // @ts-expect-error while `number[] | string[]` and `(number | string)[]` are not interchangeable
+    // this is valid because we are constructing an array of length 1, so every element of the array is the same type
+    return new TransactionSearchParams(Array.isArray(gatewayAccountIds) ? gatewayAccountIds : [gatewayAccountIds])
+  }
+
+  static forAgreement(gatewayAccountId: number, agreementExternalId: string, currentPage: number, displaySize: number) {
+    const searchParams = TransactionSearchParams.Builder(gatewayAccountId).withPagination(displaySize)
+    searchParams.page = currentPage
+    searchParams.agreementId = agreementExternalId
+    return searchParams
+  }
+
+  withDefaultDateFilter(dateFilter: Period) {
+    if (!this.dateFilter && !this.fromDate && !this.toDate) {
+      const dateRange = getPeriodUKDateTimeRange(dateFilter)
+      this.dateFilter = dateFilter
+      this.fromDate = dateRange.start
+      this.toDate = dateRange.end
+      this.includeTime = false
     }
+    return this
+  }
+
+  withPagination(displaySize: number) {
+    this.hasPagination = true
+    this.limitTotal = true
+    this.limitTotalSize = 5001
+    this.displaySize = displaySize
+    return this
+  }
+
+  withSearchQuery(queryParams: TransactionSearchQuery) {
+    if (this.hasPagination) {
+      this.page = parsePageNumber(typeof queryParams.page === 'string' ? queryParams.page : `${queryParams.page}`)
+    }
+
+    this.baseQuery = queryParams
+    this.cardholderName = nonEmpty(queryParams.cardholderName)
+    this.lastDigitsCardNumber = nonEmpty(queryParams.lastDigitsCardNumber)
+    this.metadataValue = nonEmpty(queryParams.metadataValue)
+    this.reference = nonEmpty(queryParams.reference)
+    this.email = nonEmpty(queryParams.email)
+    this.brand = parseAsArray(queryParams.brand)
+
+    Object.assign(this, processDateAndTime(queryParams))
+
+    const selectedStateFilters = parseAsArray(queryParams.state)
+    if (selectedStateFilters) {
+      const stateFilters = convertStateFilter(selectedStateFilters)
+
+      this.state = selectedStateFilters
+      this.paymentStates = stateFilters.paymentStates
+      this.refundStates = stateFilters.refundStates
+      this.disputeStates = stateFilters.disputeStates
+    }
+
+    if (queryParams.gatewayPayoutId) {
+      this.gatewayPayoutId = queryParams.gatewayPayoutId
+    }
+
+    return this
+  }
+
+  withFeeHeaders(includeFeeHeaders?: boolean) {
+    this.feeHeaders = includeFeeHeaders
+    return this
+  }
+
+  withMotoHeader(includeMotoHeader?: boolean) {
+    this.motoHeader = includeMotoHeader
+    return this
   }
 
   toJson() {
@@ -112,72 +180,6 @@ export class TransactionSearchParams {
     filters.delete('page')
     filters.delete('jsEnabled')
     return filters.size === 1 && filters.get('dateFilter') === Period.ALL_TIME
-  }
-
-  withDefaultDateFilter(dateFilter: Period) {
-    if (!this.dateFilter && !this.fromDate && !this.toDate) {
-      const dateRange = getPeriodUKDateTimeRange(dateFilter)
-      this.dateFilter = dateFilter
-      this.fromDate = dateRange.start
-      this.toDate = dateRange.end
-      this.includeTime = false
-    }
-    return this
-  }
-
-  static forAgreement(gatewayAccountId: number, agreementExternalId: string, currentPage: number, displaySize: number) {
-    const searchParams = new TransactionSearchParams([gatewayAccountId], true)
-    searchParams.page = currentPage
-    searchParams.displaySize = displaySize
-    searchParams.agreementId = agreementExternalId
-    return searchParams
-  }
-
-  static fromSearchQuery(
-    gatewayAccountIds: number | number[] | string | string[],
-    queryParams: TransactionSearchQuery,
-    withPagination: boolean,
-    pageSize?: number
-  ) {
-    // @ts-expect-error while `number[] | string[]` and `(number | string)[]` are not interchangeable
-    // this is valid because we are constructing an array of length 1, so every element of the array is the same type
-    const accountIds: number[] | string[] = Array.isArray(gatewayAccountIds) ? gatewayAccountIds : [gatewayAccountIds]
-    const searchParams = new TransactionSearchParams(accountIds, withPagination)
-
-    if (withPagination) {
-      searchParams.page = parsePageNumber(
-        typeof queryParams.page === 'string' ? queryParams.page : `${queryParams.page}`
-      )
-      searchParams.displaySize = pageSize
-    }
-
-    searchParams.baseQuery = queryParams
-
-    searchParams.cardholderName = nonEmpty(queryParams.cardholderName)
-    searchParams.lastDigitsCardNumber = nonEmpty(queryParams.lastDigitsCardNumber)
-    searchParams.metadataValue = nonEmpty(queryParams.metadataValue)
-    searchParams.reference = nonEmpty(queryParams.reference)
-    searchParams.email = nonEmpty(queryParams.email)
-
-    searchParams.brand = parseAsArray(queryParams.brand)
-
-    Object.assign(searchParams, processDateAndTime(queryParams))
-
-    const selectedStateFilters = parseAsArray(queryParams.state)
-    if (selectedStateFilters) {
-      const stateFilters = convertStateFilter(selectedStateFilters)
-
-      searchParams.state = selectedStateFilters
-      searchParams.paymentStates = stateFilters.paymentStates
-      searchParams.refundStates = stateFilters.refundStates
-      searchParams.disputeStates = stateFilters.disputeStates
-    }
-
-    if (queryParams.gatewayPayoutId) {
-      searchParams.gatewayPayoutId = queryParams.gatewayPayoutId
-    }
-
-    return searchParams
   }
 }
 

--- a/src/models/transaction/TransactionSearchParams.test.ts
+++ b/src/models/transaction/TransactionSearchParams.test.ts
@@ -1,18 +1,227 @@
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
+import sinon from 'sinon'
+import { afterEach, beforeEach } from 'mocha'
+import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { expect } from 'chai'
 
 describe('Transaction search params tests', () => {
+  let clock: sinon.SinonFakeTimers
+
+  beforeEach(() => {
+    // January 15, 2025, 14:30:00 UTC as fixed "now"
+    const fixedDate = new Date('2025-01-15T14:30:00.000Z')
+    clock = sinon.useFakeTimers(fixedDate)
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
   it('should produce correct query params when only a gatewayPayoutId is provided', () => {
     const testGatewayAccountIds = ['1', '2', '3']
-
-    const searchParams = TransactionSearchParams.fromSearchQuery(
-      testGatewayAccountIds,
-      {
-        gatewayPayoutId: 'gateway-payout-id-abc-123',
-      },
-      false
-    )
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountIds).withSearchQuery({
+      gatewayPayoutId: 'gateway-payout-id-abc-123',
+    })
 
     const queryString = searchParams.toJson().asQueryString()
     queryString.should.eq('account_id=1%2C2%2C3&gateway_payout_id=gateway-payout-id-abc-123')
+  })
+
+  it('should allow setting fee headers', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({}).withFeeHeaders(true)
+
+    const queryString = searchParams.toJson().asQueryString()
+    queryString.should.eq('account_id=1&fee_headers=true')
+  })
+
+  it('should allow setting moto header', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({}).withMotoHeader(true)
+
+    const queryString = searchParams.toJson().asQueryString()
+    queryString.should.eq('account_id=1&moto_header=true')
+  })
+
+  it('should allow setting default date params', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withDefaultDateFilter(
+      Period.LAST_12_MONTHS
+    )
+
+    const ledgerQuery = searchParams.toJson()
+    ledgerQuery.from_date!.should.eq('2024-01-15T00:00:00.000Z')
+    ledgerQuery.to_date!.should.eq('2025-01-15T23:59:59.999Z')
+
+    const queryString = ledgerQuery.asQueryString()
+    queryString.should.eq(
+      `account_id=1&from_date=${encodeURIComponent('2024-01-15T00:00:00.000Z')}&to_date=${encodeURIComponent('2025-01-15T23:59:59.999Z')}`
+    )
+  })
+
+  it('should allow setting pagination', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withPagination(20).withSearchQuery({})
+
+    const ledgerQuery = searchParams.toJson()
+    ledgerQuery.limit_total!.should.eq(true)
+    ledgerQuery.limit_total_size!.should.eq('5001')
+    ledgerQuery.display_size!.should.eq('20')
+    ledgerQuery.page!.should.eq('1')
+
+    const queryString = ledgerQuery.asQueryString()
+    queryString.should.eq('account_id=1&limit_total=true&limit_total_size=5001&display_size=20&page=1')
+  })
+
+  it('should ignore empty string values in the search query', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+      reference: 'test-reference',
+      cardholderName: '',
+      metadataValue: '',
+      email: '',
+      state: 'success',
+    })
+
+    const ledgerQuery = searchParams.toJson()
+    ledgerQuery.reference!.should.eq('test-reference')
+    ledgerQuery.payment_states!.should.eq('success')
+
+    expect(ledgerQuery.cardholder_name).to.be.undefined
+    expect(ledgerQuery.metadata_value).to.be.undefined
+    expect(ledgerQuery.email).to.be.undefined
+
+    const queryString = ledgerQuery.asQueryString()
+    queryString.should.eq('account_id=1&reference=test-reference&payment_states=success')
+  })
+
+  describe('state filter tests', () => {
+    it('should correctly handle a single state', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: 'success',
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      ledgerQuery.payment_states!.should.eq('success')
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq('account_id=1&payment_states=success')
+    })
+
+    it('should correctly handle payment states', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: ['success', 'declined'],
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      ledgerQuery.payment_states!.should.eq('success,declined')
+      expect(ledgerQuery.refund_states).to.be.undefined
+      expect(ledgerQuery.dispute_states).to.be.undefined
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(`account_id=1&payment_states=${encodeURIComponent('success,declined')}`)
+    })
+
+    it('should correctly handle refund states', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: ['refund_success', 'refund_error'],
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      expect(ledgerQuery.payment_states).to.be.undefined
+      ledgerQuery.refund_states!.should.eq('success,error')
+      expect(ledgerQuery.dispute_states).to.be.undefined
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(`account_id=1&refund_states=${encodeURIComponent('success,error')}`)
+    })
+
+    it('should correctly handle dispute states', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: ['dispute_awaiting_evidence', 'dispute_under_review', 'dispute_won'],
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      expect(ledgerQuery.payment_states).to.be.undefined
+      expect(ledgerQuery.refund_states).to.be.undefined
+      ledgerQuery.dispute_states!.should.eq('needs_response,under_review,won')
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(`account_id=1&dispute_states=${encodeURIComponent('needs_response,under_review,won')}`)
+    })
+
+    it('should correctly handle multiple transaction type states', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: [
+          'cancelled',
+          'error',
+          'timed_out',
+          'refund_submitted',
+          'dispute_awaiting_evidence',
+          'dispute_under_review',
+          'dispute_won',
+        ],
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      ledgerQuery.payment_states!.should.eq('cancelled,error,timedout')
+      ledgerQuery.refund_states!.should.eq('submitted')
+      ledgerQuery.dispute_states!.should.eq('needs_response,under_review,won')
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(
+        `account_id=1&payment_states=${encodeURIComponent('cancelled,error,timedout')}&refund_states=${encodeURIComponent('submitted')}&dispute_states=${encodeURIComponent('needs_response,under_review,won')}`
+      )
+    })
+
+    it('should correctly handle states as a csv list instead of an array', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: 'success,cancelled,timed_out,refund_created,refund_error,dispute_lost',
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      ledgerQuery.payment_states!.should.eq('success,cancelled,timedout')
+      ledgerQuery.refund_states!.should.eq('created,error')
+      ledgerQuery.dispute_states!.should.eq('lost')
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(
+        `account_id=1&payment_states=${encodeURIComponent('success,cancelled,timedout')}&refund_states=${encodeURIComponent('created,error')}&dispute_states=${encodeURIComponent('lost')}`
+      )
+    })
+
+    it('should ignore erroneous states', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({
+        state: [
+          'cancelled',
+          'pending',
+          'notastate',
+          'this is also not a state',
+          'refund_rejected_for_some_reason',
+          'refund_not_allowed',
+          'refund_this_is_not_a_state',
+          'dispute_cancelled_by_user_for_some_reason',
+          'dispute_won',
+          'dispute_lost',
+          'transaction_invalid',
+          '1234567890',
+        ],
+      })
+
+      const ledgerQuery = searchParams.toJson()
+      ledgerQuery.payment_states!.should.eq('cancelled')
+      expect(ledgerQuery.refund_states).to.be.undefined
+      ledgerQuery.dispute_states!.should.eq('won,lost')
+
+      const queryString = ledgerQuery.asQueryString()
+      queryString.should.eq(`account_id=1&payment_states=cancelled&dispute_states=${encodeURIComponent('won,lost')}`)
+    })
   })
 })

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -21,6 +21,8 @@ export class TransactionSearchParamsData {
   readonly refund_states?: string
   readonly dispute_states?: string
   readonly gateway_payout_id?: string
+  readonly fee_headers?: boolean
+  readonly moto_header?: boolean
 
   constructor(params: TransactionSearchParams) {
     this.account_id = params.accountIds.join(',')
@@ -42,6 +44,8 @@ export class TransactionSearchParamsData {
     this.refund_states = params.refundStates?.map(toLower).join(',')
     this.dispute_states = params.disputeStates?.map(toLower).join(',')
     this.gateway_payout_id = params.gatewayPayoutId
+    this.fee_headers = params.feeHeaders
+    this.moto_header = params.motoHeader
   }
 
   asQueryString(): string {

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
@@ -79,7 +79,10 @@ describe('All Service Transactions list', () => {
       cy.task('setupStubs', [
         getUser(USER_EXTERNAL_ID).success(userWithStripeService),
         searchTransactions(
-          TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20).withDefaultDateFilter('last-12-months')
+          TransactionSearchParams.Builder(accountIds)
+            .withPagination(20)
+            .withDefaultDateFilter('last-12-months')
+            .withSearchQuery({})
         ).success([STRIPE_TRANSACTION, WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([
           SANDBOX_SERVICE.externalId,
@@ -150,7 +153,10 @@ describe('All Service Transactions list', () => {
       cy.task('setupStubs', [
         getUser(USER_EXTERNAL_ID).success(userWithoutStripeService),
         searchTransactions(
-          TransactionSearchParams.fromSearchQuery(accountIds, {}, true, 20).withDefaultDateFilter('last-12-months')
+          TransactionSearchParams.Builder(accountIds)
+            .withPagination(20)
+            .withDefaultDateFilter('last-12-months')
+            .withSearchQuery({})
         ).success([WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([SANDBOX_SERVICE.externalId, WORLDPAY_SERVICE.externalId]).success([
           TEST_SANDBOX_ACCOUNT,

--- a/test/cypress/stubs/simplified-account/card-types-stubs.ts
+++ b/test/cypress/stubs/simplified-account/card-types-stubs.ts
@@ -1,0 +1,14 @@
+import { stubBuilder } from '@test/cypress/stubs/stub-builder'
+import cardFixtures from '@test/fixtures/card.fixtures'
+
+export function getAllCardTypes() {
+  const path = `/v1/api/card-types`
+
+  return {
+    success: function () {
+      return stubBuilder('GET', path, 200, {
+        response: cardFixtures.validCardTypesResponse(),
+      })
+    },
+  }
+}

--- a/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
+++ b/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
@@ -17,3 +17,15 @@ export function searchByServiceExternalIds(serviceExternalIds: string[]) {
     },
   }
 }
+
+export function getByServiceExternalIdAndAccountType(serviceExternalId: string, accountType: string) {
+  const path = `/v1/api/service/${serviceExternalId}/account/${accountType}`
+
+  return {
+    success: function (gatewayAccount: GatewayAccountFixture) {
+      return stubBuilder('GET', path, 200, {
+        response: gatewayAccount.toGatewayAccountData(),
+      })
+    },
+  }
+}

--- a/test/cypress/stubs/simplified-account/transaction-stubs.ts
+++ b/test/cypress/stubs/simplified-account/transaction-stubs.ts
@@ -81,6 +81,20 @@ function searchTransactions(query: TransactionSearchParams) {
   }
 }
 
+function searchTransactionsDefault(accountIds: number | number[] | string | string[]) {
+  const query = TransactionSearchParams.Builder(accountIds)
+    .withPagination(20)
+    .withDefaultDateFilter('last-12-months')
+    .withSearchQuery({})
+  const searchStub = searchTransactions(query)
+
+  return {
+    success: function (transactions: TransactionFixture[]) {
+      return searchStub.success(transactions)
+    },
+  }
+}
+
 function getTransactionEvents(gatewayAccountId: string, transactionExternalId: string) {
   const path = `/v1/transaction/${transactionExternalId}/event`
 
@@ -147,5 +161,6 @@ export {
   getTransactionEvents,
   getTransactionDisputes,
   searchTransactions,
+  searchTransactionsDefault,
   postRefund,
 }

--- a/test/fixtures/card.fixtures.ts
+++ b/test/fixtures/card.fixtures.ts
@@ -1,120 +1,145 @@
-'use strict'
+import { CardTypeData } from '@models/card-type/dto/CardType.dto'
 
-module.exports = {
-  validCardTypesResponse: () => {
-    return {
-      card_types: [{
+interface CardTypesResponse {
+  card_types: CardTypeData[]
+}
+
+function validCardTypesResponse(): CardTypesResponse {
+  return {
+    card_types: [
+      {
         id: 'a1200c73-204d-45f5-8fca-e4ee5ed1b1a7',
         brand: 'visa',
         label: 'Visa',
         type: 'DEBIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: 'd03f5008-f793-4ea5-8a23-87f40ceb6c81',
         brand: 'visa',
         label: 'Visa',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '491df314-fcb1-428f-9ea8-320865cf2a29',
         brand: 'master-card',
         label: 'Mastercard',
         type: 'DEBIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '667cad4d-8ef9-418b-8023-5c8922f82d7a',
         brand: 'master-card',
         label: 'Mastercard',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: 'fff66fd7-e1d6-4c65-846d-9199c906e368',
         brand: 'american-express',
         label: 'American Express',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '2d5462a8-fb95-4a5a-b991-3891e40312f3',
         brand: 'diners-club',
         label: 'Diners Club',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '29b87115-9b09-419e-a593-d9f1f5375dbd',
         brand: 'discover',
         label: 'Discover',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: 'ca5ba07b-aa4b-4294-8fd0-8354fc383e28',
         brand: 'jcb',
         label: 'Jcb',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '09edd87d-d4cb-4fdd-a03c-40c5e3dc08dc',
         brand: 'unionpay',
         label: 'Union Pay',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '778e32ef-5314-4a42-897d-d06986bc9465',
         brand: 'maestro',
         label: 'Maestro',
         type: 'DEBIT',
-        requires3ds: true
-      }]
-    }
-  },
-  validAcceptedCardTypesResponse: opts => {
-    const data = {
-      card_types: [{
+        requires3ds: true,
+      },
+    ],
+  }
+}
+
+function validAcceptedCardTypesResponse(opts: { toggleAmex: boolean; maestro: boolean }): CardTypesResponse {
+  const data = {
+    card_types: [
+      {
         id: 'a1200c73-204d-45f5-8fca-e4ee5ed1b1a7',
         brand: 'visa',
         label: 'Visa',
         type: 'DEBIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: 'd03f5008-f793-4ea5-8a23-87f40ceb6c81',
         brand: 'visa',
         label: 'Visa',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '491df314-fcb1-428f-9ea8-320865cf2a29',
         brand: 'master-card',
         label: 'Mastercard',
         type: 'DEBIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: '667cad4d-8ef9-418b-8023-5c8922f82d7a',
         brand: 'master-card',
         label: 'Mastercard',
         type: 'CREDIT',
-        requires3ds: false
-      }, {
+        requires3ds: false,
+      },
+      {
         id: 'fff66fd7-e1d6-4c65-846d-9199c906e368',
         brand: 'american-express',
         label: 'American Express',
         type: 'CREDIT',
-        requires3ds: false
-      }]
-    }
-
-    if (opts.toggleAmex) {
-      data.card_types.pop()
-    }
-
-    if (opts.maestro) {
-      data.card_types.push({
-        id: '778e32ef-5314-4a42-897d-d06986bc9465',
-        brand: 'maestro',
-        label: 'Maestro',
-        type: 'DEBIT',
-        requires3ds: true
-      })
-    }
-
-    return data
+        requires3ds: false,
+      },
+    ],
   }
+
+  if (opts.toggleAmex) {
+    data.card_types.pop()
+  }
+
+  if (opts.maestro) {
+    data.card_types.push({
+      id: '778e32ef-5314-4a42-897d-d06986bc9465',
+      brand: 'maestro',
+      label: 'Maestro',
+      type: 'DEBIT',
+      requires3ds: true,
+    })
+  }
+
+  return data
+}
+
+export = {
+  validCardTypesResponse,
+  validAcceptedCardTypesResponse,
 }

--- a/test/fixtures/user/user.fixture.ts
+++ b/test/fixtures/user/user.fixture.ts
@@ -1,6 +1,8 @@
 import UserData from '@models/user/dto/User.dto'
 import User from '@models/user/User.class'
 import { ServiceRoleFixture } from '@test/fixtures/user/service-role.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { RoleFixture } from '@test/fixtures/service/role.fixture'
 
 export class UserFixture {
   readonly externalId: string
@@ -16,7 +18,7 @@ export class UserFixture {
   readonly internalUser: boolean
   readonly numberOfLiveServices: number
 
-  constructor(overrides?: Partial<UserFixture>) {
+  constructor(...overrides: Partial<UserFixture>[]) {
     this.externalId = 'user-123-external-id'
     this.email = 'homer.simpson@example.com'
     this.serviceRoles = [new ServiceRoleFixture()]
@@ -30,9 +32,18 @@ export class UserFixture {
     this.internalUser = false
     this.numberOfLiveServices = 0
 
-    if (overrides) {
-      Object.assign(this, overrides)
-    }
+    overrides?.forEach((override) => {
+      Object.assign(this, override)
+    })
+  }
+
+  static asServiceAdmin(services: ServiceFixture[], ...overrides: Partial<UserFixture>[]) {
+    return new UserFixture(
+      {
+        serviceRoles: services.map((service) => new ServiceRoleFixture({ service, role: RoleFixture.Admin() })),
+      },
+      ...overrides
+    )
   }
 
   toUserData(): UserData {


### PR DESCRIPTION
## What

PP-15481

 - Fix `moto_header` and `fee_headers` params missing from requests to Ledger `/v1/transaction` search endpoint
   - this resulted in some columns being missing from CSV downloads
 - Migrate `TransactionSearchParams` to a builder-like pattern, making its use in controllers cleaner.
 - Use `ViewMode` in All Service Transactions CSV download to determine whether to include MOTO and fee headers, since all a user's gateway accounts are already retrieved by the view mode middleware
 - Add tests for  `TransactionSearchParams`


This also adds some Typescript stubs for Cypress tests which are not currently used. These were to be used in a CSV download Cypress test, however as the responsibility for correctly sending the CSV data is largely handled by Ledger, there is not much value gained from a Cypress test which stubs out the relevant Ledger request.

The Typescript stubs have been left in as they will likely be useful in the future. Uses of existing Javascript stubs could be migrated over to these at any time.