### PR TITLE
PP-15481 Ensure filters correctly persist from search to CSV download

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -99,7 +99,7 @@ async function get(
   const pagination = getPagination(currentPage, MAX_TRANSACTIONS_PER_PAGE, results.total, path)
 
   const downloadUrl = formattedPathFor(paths.allServiceTransactions.simplifiedAccount.download, req.viewMode.modeName)
-  const downloadQueryString = transactionSearchParams.getQueryParams().toString()
+  const downloadQueryString = transactionSearchParams.toQueryRecreationPrams().toString()
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -71,7 +71,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
     req.service.externalId,
     req.account.type
   )
-  const downloadQueryString = transactionSearchParams.getQueryParams().toString()
+  const downloadQueryString = transactionSearchParams.toQueryRecreationPrams().toString()
   const downloadLink = downloadQueryString.length ? `${downloadUrl}?${downloadQueryString}` : downloadUrl
   const transactionCountWithinRange = results.total > 0 && results.total <= LEDGER_TRANSACTION_COUNT_LIMIT
 

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -12,10 +12,11 @@ import {
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { parseTransactionSearchDateTime } from '@utils/time/parse-date-time'
 import type { DateTime } from 'luxon'
-import { TRANSACTION_SEARCH_DATE_FORMAT } from '@utils/time/time-formats'
+import { TRANSACTION_SEARCH_DATE_FORMAT, TRANSACTION_SEARCH_TIME_FORMAT } from '@utils/time/time-formats'
 import { TimeConstants } from '@utils/time/time-constants'
+import { omit } from 'lodash'
 
-interface TransactionSearchQuery {
+export interface TransactionSearchQuery {
   cardholderName?: string
   lastDigitsCardNumber?: string
   metadataValue?: string
@@ -58,9 +59,11 @@ export class TransactionSearchParams {
   gatewayPayoutId?: string
   motoHeader?: boolean
   feeHeaders?: boolean
-  baseQuery?: TransactionSearchQuery
-  includeTime?: boolean
-  hasPagination?: boolean
+
+  private includeTime?: boolean
+  private baseQuery?: TransactionSearchQuery
+  private hasPagination?: boolean
+  private filterCount?: number
 
   constructor(gatewayAccountIds: number[] | string[]) {
     this.accountIds = gatewayAccountIds
@@ -99,6 +102,7 @@ export class TransactionSearchParams {
   }
 
   withSearchQuery(queryParams: TransactionSearchQuery) {
+    this.filterCount = countFilters(queryParams)
     if (this.hasPagination) {
       this.page = parsePageNumber(typeof queryParams.page === 'string' ? queryParams.page : `${queryParams.page}`)
     }
@@ -144,10 +148,29 @@ export class TransactionSearchParams {
     return new TransactionSearchParamsData(this)
   }
 
-  getQueryParams() {
+  // query params to recreate the same search
+  toQueryRecreationPrams() {
+    const params: Record<string, string | undefined> = {
+      cardholderName: this.cardholderName,
+      lastDigitsCardNumber: this.lastDigitsCardNumber,
+      metadataValue: this.metadataValue,
+      brand: this.brand?.join(','),
+      reference: this.reference,
+      email: this.email,
+      dateFilter: this.dateFilter,
+      state: this.state?.join(','),
+      page: this.page?.toString(),
+      fromDate: this.fromDate?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT),
+      toDate: this.toDate?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT),
+      fromTime: this.includeTime ? this.fromDate?.toFormat(TRANSACTION_SEARCH_TIME_FORMAT) : undefined,
+      toTime: this.includeTime ? this.toDate?.toFormat(TRANSACTION_SEARCH_TIME_FORMAT) : undefined,
+      includeTime: this.includeTime ? 'include' : undefined,
+      gatewayPayoutId: this.gatewayPayoutId,
+    }
+
     const urlParams = new URLSearchParams()
 
-    Object.entries(this.baseQuery as Record<string, string>).forEach(([key, value]: [string, string]) => {
+    Object.entries(params as Record<string, string>).forEach(([key, value]: [string, string]) => {
       if (value !== undefined && value !== null) {
         urlParams.set(key, value)
       }
@@ -169,17 +192,13 @@ export class TransactionSearchParams {
   }
 
   hasUserSelectedFilters() {
-    const filters = this.getQueryParams()
-    filters.delete('page')
-    filters.delete('jsEnabled')
-    return filters.size > 0
+    return this.filterCount === undefined ? false : this.filterCount > 0
   }
 
   isUnfilteredAllTimeSearch() {
-    const filters = this.getQueryParams()
-    filters.delete('page')
-    filters.delete('jsEnabled')
-    return filters.size === 1 && filters.get('dateFilter') === Period.ALL_TIME
+    return this.filterCount === undefined
+      ? false
+      : this.filterCount === 1 && this.baseQuery?.dateFilter === Period.ALL_TIME
   }
 }
 
@@ -290,4 +309,10 @@ function parseAsArray(queryParam: string[] | string | undefined): string[] | und
   } else {
     return queryParam.split(',')
   }
+}
+
+function countFilters(query: TransactionSearchQuery): number {
+  return Object.values(omit(query, ['page', 'jsEnabled'])).filter(
+    (queryParam) => !(queryParam === '' || queryParam === null || queryParam === undefined)
+  ).length
 }

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -63,10 +63,11 @@ export class TransactionSearchParams {
   private includeTime?: boolean
   private baseQuery?: TransactionSearchQuery
   private hasPagination?: boolean
-  private filterCount?: number
+  private filterCount: number
 
   constructor(gatewayAccountIds: number[] | string[]) {
     this.accountIds = gatewayAccountIds
+    this.filterCount = 0
   }
 
   static Builder(gatewayAccountIds: number | number[] | string | string[]) {
@@ -192,13 +193,11 @@ export class TransactionSearchParams {
   }
 
   hasUserSelectedFilters() {
-    return this.filterCount === undefined ? false : this.filterCount > 0
+    return this.filterCount > 0
   }
 
   isUnfilteredAllTimeSearch() {
-    return this.filterCount === undefined
-      ? false
-      : this.filterCount === 1 && this.baseQuery?.dateFilter === Period.ALL_TIME
+    return this.filterCount === 1 && this.baseQuery?.dateFilter === Period.ALL_TIME
   }
 }
 

--- a/src/models/transaction/TransactionSearchParams.test.ts
+++ b/src/models/transaction/TransactionSearchParams.test.ts
@@ -1,8 +1,10 @@
-import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
+import { TransactionSearchParams, TransactionSearchQuery } from '@models/transaction/TransactionSearchParams.class'
 import sinon from 'sinon'
 import { afterEach, beforeEach } from 'mocha'
 import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
 import { expect } from 'chai'
+import { MAX_TRANSACTIONS_PER_PAGE } from '@controllers/simplified-account/services/transactions/constants'
+import * as querystring from 'node:querystring'
 
 describe('Transaction search params tests', () => {
   let clock: sinon.SinonFakeTimers
@@ -222,6 +224,252 @@ describe('Transaction search params tests', () => {
 
       const queryString = ledgerQuery.asQueryString()
       queryString.should.eq(`account_id=1&payment_states=cancelled&dispute_states=${encodeURIComponent('won,lost')}`)
+    })
+  })
+
+  describe('search query recreation tests', () => {
+    it('should successfully recreate an empty search query', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery({})
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate the default search query', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({})
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate a complex search query', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({
+          cardholderName: 'Homer J Simpson',
+          lastDigitsCardNumber: '1234',
+          metadataValue: 'some metadata',
+          brand: 'visa,mastercard',
+          reference: 'DONUTS1234',
+          email: 'homer.simpson@example.com',
+          state: 'success,timed_out,error',
+          page: '3',
+        })
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate a query with a date filter', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({
+          dateFilter: 'yesterday',
+        })
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate a query with a date range', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({
+          dateFilter: 'yesterday',
+          fromDate: '14/01/2025',
+          toDate: '14/01/2025',
+        })
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate a query with a date range where JS is disabled', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({
+          dateFilter: 'last-12-months', // deliberately different to the entered dates
+          fromDate: '14/01/2025',
+          toDate: '14/01/2025',
+          jsEnabled: 'false',
+        })
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should successfully recreate a query with a time range included', () => {
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery({
+          dateFilter: 'custom-range',
+          fromDate: '14/09/2024',
+          toDate: '07/01/2025',
+          fromTime: '2:30:00',
+          toTime: '11:45:00',
+        })
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const ledgerQuery = searchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      ledgerQuery.should.deep.eq(recreatedLedgerQuery)
+      ledgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should allow for query recreation without pagination', () => {
+      const searchQuery = {
+        cardholderName: 'Homer J Simpson',
+        lastDigitsCardNumber: '1234',
+        metadataValue: 'some metadata',
+        brand: 'visa,mastercard',
+        reference: 'DONUTS1234',
+        email: 'homer.simpson@example.com',
+        state: 'success,timed_out,error',
+      }
+
+      const testGatewayAccountId = 1
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(searchQuery)
+
+      const noPaginationSearchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withSearchQuery(searchQuery)
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId).withSearchQuery(recreationQuery)
+
+      const noPaginationLedgerQuery = noPaginationSearchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      noPaginationLedgerQuery.should.deep.eq(recreatedLedgerQuery)
+      expect(recreatedLedgerQuery.page).to.be.undefined
+      expect(recreatedLedgerQuery.limit_total).to.be.undefined
+      expect(recreatedLedgerQuery.limit_total_size).to.be.undefined
+
+      noPaginationLedgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
+    })
+
+    it('should allow for query recreation without a default date filter', () => {
+      const testGatewayAccountId = 1
+      const query = {
+        dateFilter: 'yesterday',
+        fromDate: '14/01/2025',
+        toDate: '14/01/2025',
+      }
+      const searchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withDefaultDateFilter(Period.LAST_12_MONTHS)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(query)
+
+      const noDefaultDateFilterSearchParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(query)
+
+      const recreationQuery = querystring.parse(
+        searchParams.toQueryRecreationPrams().toString()
+      ) as TransactionSearchQuery
+
+      const recreatedParams = TransactionSearchParams.Builder(testGatewayAccountId)
+        .withPagination(MAX_TRANSACTIONS_PER_PAGE)
+        .withSearchQuery(recreationQuery)
+
+      const noDefaultDateFilterLedgerQuery = noDefaultDateFilterSearchParams.toJson()
+      const recreatedLedgerQuery = recreatedParams.toJson()
+
+      noDefaultDateFilterLedgerQuery.should.deep.eq(recreatedLedgerQuery)
+      noDefaultDateFilterLedgerQuery.asQueryString().should.eq(recreatedLedgerQuery.asQueryString())
     })
   })
 })


### PR DESCRIPTION
## What

PP-15481

When loading the transaction search, the default `last-12-months` date filter is selected, however the CSV download link that is generated does not include any filters. This means that a CSV of all transactions is generated if the user clicks the CSV download link on first visiting the page.

This fixes this behaviour, to ensure filters are always applied to the CSV download, and that these filters will successfully recreate the same search query.

This also changes the way in which it is checked if filters are applied (for the purpose of showing/hiding the CSV download button) to simply counting the filters directly