### PR TITLE
PP-15481 Fix all transactions for agreement link

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -23,6 +23,7 @@ import {
   MAX_TRANSACTIONS_PER_PAGE,
 } from '@controllers/simplified-account/services/transactions/constants'
 import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { NonEmptyString } from '@utils/types/non-empty-string'
 
 async function get(
   req: AuthenticatedRequest & { viewMode: ViewMode },
@@ -84,7 +85,7 @@ async function get(
     return {
       value: card.brand,
       text: card.label === 'Jcb' ? card.label.toUpperCase() : card.label,
-      selected: transactionSearchParams.brand?.includes(card.brand),
+      selected: transactionSearchParams.brand?.includes(card.brand as NonEmptyString),
     }
   })
 

--- a/src/controllers/simplified-account/services/agreements/detail/agreement-detail.controller.ts
+++ b/src/controllers/simplified-account/services/agreements/detail/agreement-detail.controller.ts
@@ -4,6 +4,7 @@ import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
 import formatAccountPathsFor from '@utils/format-account-paths-for'
+import { Features } from '@root/config/features'
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
   const agreementsFilter = req.session.agreementsFilter as string
@@ -25,7 +26,9 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
       req.account.type,
       agreement.externalId
     ),
-    allAgreementTransactionsLink: `${formatAccountPathsFor(paths.account.transactions.index, req.account.externalId)}?agreementId=${agreement.externalId}`, // todo move me to service model when transactions are updated
+    allAgreementTransactionsLink: Features.isEnabled(Features.TRANSACTIONS)
+      ? `${formatServiceAndAccountPathsFor(paths.simplifiedAccount.transactions.index, req.service.externalId, req.account.type)}?agreementId=${agreement.externalId}`
+      : `${formatAccountPathsFor(paths.account.transactions.index, req.account.externalId)}?agreementId=${agreement.externalId}`, // todo move me to service model when transactions are updated
   })
 }
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@utils/simplified-account/services/transactions/status-filters'
 import { LEDGER_TRANSACTION_COUNT_LIMIT, MAX_TRANSACTIONS_PER_PAGE } from './constants'
 import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import { NonEmptyString } from '@utils/types/non-empty-string'
 
 const getUrlGenerator = (filters: Record<string, string>, transactionsUrl: string) => {
   const getPath = (pageNumber: number) => {
@@ -56,7 +57,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
     return {
       value: card.brand,
       text: card.label === 'Jcb' ? card.label.toUpperCase() : card.label,
-      selected: transactionSearchParams.brand?.includes(card.brand),
+      selected: transactionSearchParams.brand?.includes(card.brand as NonEmptyString),
     }
   })
 

--- a/src/models/transaction/TransactionSearchParams.class.ts
+++ b/src/models/transaction/TransactionSearchParams.class.ts
@@ -15,48 +15,50 @@ import type { DateTime } from 'luxon'
 import { TRANSACTION_SEARCH_DATE_FORMAT, TRANSACTION_SEARCH_TIME_FORMAT } from '@utils/time/time-formats'
 import { TimeConstants } from '@utils/time/time-constants'
 import { omit } from 'lodash'
+import { nonEmpty, NonEmptyString, nonEmptyStringArray } from '@utils/types/non-empty-string'
 
 export interface TransactionSearchQuery {
-  cardholderName?: string
-  lastDigitsCardNumber?: string
-  metadataValue?: string
-  brand?: string | string[]
-  reference?: string
-  email?: string
-  dateFilter?: string
-  state?: string | string[]
-  page?: string | number
-  fromDate?: string
-  toDate?: string
-  fromTime?: string
-  toTime?: string
-  includeTime?: string
-  gatewayPayoutId?: string
-  jsEnabled?: string
+  cardholderName?: unknown
+  lastDigitsCardNumber?: unknown
+  metadataValue?: unknown
+  brand?: unknown
+  reference?: unknown
+  email?: unknown
+  dateFilter?: unknown
+  state?: unknown
+  page?: unknown
+  fromDate?: unknown
+  toDate?: unknown
+  fromTime?: unknown
+  toTime?: unknown
+  includeTime?: unknown
+  gatewayPayoutId?: unknown
+  agreementId?: unknown
+  jsEnabled?: unknown
 }
 
 export class TransactionSearchParams {
   accountIds: number[] | string[]
-  agreementId?: string
+  agreementId?: NonEmptyString
   displaySize?: number
   page?: number
   limitTotal?: boolean
   limitTotalSize?: number
-  cardholderName?: string
-  lastDigitsCardNumber?: string
-  metadataValue?: string
-  brand?: string[]
-  reference?: string
-  email?: string
-  type?: string
-  dateFilter?: string
+  cardholderName?: NonEmptyString
+  lastDigitsCardNumber?: NonEmptyString
+  metadataValue?: NonEmptyString
+  brand?: NonEmptyString[]
+  reference?: NonEmptyString
+  email?: NonEmptyString
+  type?: NonEmptyString
+  dateFilter?: Period | 'custom-range'
   fromDate?: DateTime<true>
   toDate?: DateTime<true>
   state?: string[]
   paymentStates?: string[]
   refundStates?: string[]
   disputeStates?: string[]
-  gatewayPayoutId?: string
+  gatewayPayoutId?: NonEmptyString
   motoHeader?: boolean
   feeHeaders?: boolean
 
@@ -79,7 +81,7 @@ export class TransactionSearchParams {
   static forAgreement(gatewayAccountId: number, agreementExternalId: string, currentPage: number, displaySize: number) {
     const searchParams = TransactionSearchParams.Builder(gatewayAccountId).withPagination(displaySize)
     searchParams.page = currentPage
-    searchParams.agreementId = agreementExternalId
+    searchParams.agreementId = agreementExternalId as NonEmptyString
     return searchParams
   }
 
@@ -105,7 +107,7 @@ export class TransactionSearchParams {
   withSearchQuery(queryParams: TransactionSearchQuery) {
     this.filterCount = countFilters(queryParams)
     if (this.hasPagination) {
-      this.page = parsePageNumber(typeof queryParams.page === 'string' ? queryParams.page : `${queryParams.page}`)
+      this.page = parsePageNumber(queryParams.page)
     }
 
     this.baseQuery = queryParams
@@ -128,9 +130,9 @@ export class TransactionSearchParams {
       this.disputeStates = stateFilters.disputeStates
     }
 
-    if (queryParams.gatewayPayoutId) {
-      this.gatewayPayoutId = queryParams.gatewayPayoutId
-    }
+    // not from search, linked to from other pages
+    this.gatewayPayoutId = nonEmpty(queryParams.gatewayPayoutId)
+    this.agreementId = nonEmpty(queryParams.agreementId)
 
     return this
   }
@@ -151,7 +153,7 @@ export class TransactionSearchParams {
 
   // query params to recreate the same search
   toQueryRecreationPrams() {
-    const params: Record<string, string | undefined> = {
+    const params: TransactionSearchQuery = {
       cardholderName: this.cardholderName,
       lastDigitsCardNumber: this.lastDigitsCardNumber,
       metadataValue: this.metadataValue,
@@ -167,6 +169,7 @@ export class TransactionSearchParams {
       toTime: this.includeTime ? this.toDate?.toFormat(TRANSACTION_SEARCH_TIME_FORMAT) : undefined,
       includeTime: this.includeTime ? 'include' : undefined,
       gatewayPayoutId: this.gatewayPayoutId,
+      agreementId: this.agreementId,
     }
 
     const urlParams = new URLSearchParams()
@@ -219,8 +222,12 @@ function convertStateFilter(selected: string[]): ConnectorStates {
   }
 }
 
-function parsePageNumber(pageNumber?: string) {
-  if (!pageNumber) {
+function parsePageNumber(pageNumber: unknown) {
+  if (typeof pageNumber === 'number') {
+    return pageNumber
+  }
+
+  if (typeof pageNumber !== 'string' || pageNumber === '') {
     return 1
   }
 
@@ -232,23 +239,19 @@ function parsePageNumber(pageNumber?: string) {
   return parsedPageNumber
 }
 
-const nonEmpty = (value: string | undefined) => {
-  return value === '' ? undefined : value
-}
-
-interface DateTimeSearchParams {
-  dateFilter?: string
-  fromDate?: DateTime<true>
-  toDate?: DateTime<true>
-  fromTime?: string
-  toTime?: string
+type DateTimeSearchParams = Pick<TransactionSearchParams, 'dateFilter' | 'fromDate' | 'toDate'> & {
   includeTime?: boolean
 }
 
 const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearchParams => {
+  const fromDate = asString(queryParams.fromDate)
+  const toDate = asString(queryParams.toDate)
+  const fromTime = asString(queryParams.fromTime)
+  const toTime = asString(queryParams.toTime)
+
   const searchParams: DateTimeSearchParams = {}
 
-  const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter as Period)
+  const dateRange = getPeriodUKDateTimeRange(queryParams.dateFilter)
   const isJsEnabled = queryParams.jsEnabled !== 'false'
   const isDateFilterValidPeriod = TRANSACTION_FILTER_PERIODS.has(queryParams.dateFilter as Period)
 
@@ -258,7 +261,7 @@ const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearch
   const isNoJsDateFilterSearch = !isJsEnabled && isDateFilterValidPeriod
 
   if (isJsDateFilterSearch || isNoJsDateFilterSearch) {
-    searchParams.dateFilter = queryParams.dateFilter
+    searchParams.dateFilter = dateRange.period
     searchParams.fromDate = dateRange.start
     searchParams.toDate = dateRange.end
     searchParams.includeTime = false
@@ -268,27 +271,25 @@ const processDateAndTime = (queryParams: TransactionSearchQuery): DateTimeSearch
 
   if (queryParams.fromDate || queryParams.toDate) {
     searchParams.fromDate = parseTransactionSearchDateTime(
-      queryParams.fromDate ?? '',
-      queryParams.fromTime ?? '',
+      fromDate,
+      fromTime,
       queryParams.includeTime === 'include',
       TimeConstants.TWELVE_MONTHS_AGO
     )
 
     // parse end date/time, clamp to end of day if not including time
-    const toDate = parseTransactionSearchDateTime(
-      queryParams.toDate ?? '',
-      queryParams.toTime ?? '',
+    const parsedToDate = parseTransactionSearchDateTime(
+      toDate,
+      toTime,
       queryParams.includeTime === 'include',
       TimeConstants.END_OF_TODAY
     )
-    searchParams.toDate = queryParams.includeTime === 'include' ? toDate : toDate.endOf('day')
+    searchParams.toDate = queryParams.includeTime === 'include' ? parsedToDate : parsedToDate.endOf('day')
 
     // if the selected dates match the filter, persist the filter, otherwise set to custom-range
     // this ensures the correct filter is displayed to the user
     searchParams.dateFilter =
-      isSameDate(queryParams.fromDate, dateRange.start) && isSameDate(queryParams.toDate, dateRange.end)
-        ? queryParams.dateFilter
-        : 'custom-range'
+      isSameDate(fromDate, dateRange.start) && isSameDate(toDate, dateRange.end) ? dateRange.period : 'custom-range'
 
     searchParams.includeTime = queryParams.includeTime === 'include'
   }
@@ -300,13 +301,20 @@ function isSameDate(dateString: string | undefined, date: DateTime | undefined) 
   return dateString === date?.toFormat(TRANSACTION_SEARCH_DATE_FORMAT)
 }
 
-function parseAsArray(queryParam: string[] | string | undefined): string[] | undefined {
-  if (queryParam === undefined || queryParam === '' || queryParam.length === 0) {
+function parseAsArray(queryParam: unknown): NonEmptyString[] | undefined {
+  if (
+    queryParam === undefined ||
+    queryParam === null ||
+    queryParam === '' ||
+    (Array.isArray(queryParam) && queryParam.length === 0)
+  ) {
     return undefined
   } else if (Array.isArray(queryParam)) {
-    return queryParam
+    return nonEmptyStringArray(queryParam)
+  } else if (typeof queryParam !== 'string') {
+    return undefined
   } else {
-    return queryParam.split(',')
+    return nonEmptyStringArray(queryParam.split(','))
   }
 }
 
@@ -314,4 +322,11 @@ function countFilters(query: TransactionSearchQuery): number {
   return Object.values(omit(query, ['page', 'jsEnabled'])).filter(
     (queryParam) => !(queryParam === '' || queryParam === null || queryParam === undefined)
   ).length
+}
+
+function asString(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  return value
 }

--- a/src/models/transaction/dto/TransactionSearchParams.dto.ts
+++ b/src/models/transaction/dto/TransactionSearchParams.dto.ts
@@ -26,14 +26,14 @@ export class TransactionSearchParamsData {
 
   constructor(params: TransactionSearchParams) {
     this.account_id = params.accountIds.join(',')
-    this.agreement_id = params.agreementId?.toString() ?? undefined
+    this.agreement_id = params.agreementId ?? undefined
     this.limit_total = params.limitTotal ?? undefined
     this.limit_total_size = params.limitTotalSize?.toString() ?? undefined
     this.display_size = params.displaySize?.toString() ?? undefined
     this.page = params.page?.toString()
-    this.cardholder_name = params.cardholderName?.toString() ?? undefined
+    this.cardholder_name = params.cardholderName ?? undefined
     this.last_digits_card_number = params.lastDigitsCardNumber?.toString() ?? undefined
-    this.metadata_value = params.metadataValue?.toString() ?? undefined
+    this.metadata_value = params.metadataValue ?? undefined
     this.card_brands = params.brand?.join(',') ?? undefined
     this.transaction_type = params.type ?? undefined
     this.reference = params.reference ?? undefined

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -11,6 +11,12 @@ export const Period: Record<string, Period> = {
   ALL_TIME: 'all-time',
 }
 
+const VALID_PERIODS = new Set(Object.values(Period))
+
+function isValidPeriod(period: unknown): period is Period {
+  return VALID_PERIODS.has(period as Period)
+}
+
 export type Period =
   | 'today'
   | 'yesterday'
@@ -31,6 +37,8 @@ export const TRANSACTION_FILTER_PERIODS: Set<Period> = new Set<Period>([
 interface DateTimeRange {
   start: DateTime<true> | undefined
   end: DateTime<true> | undefined
+  valid: boolean
+  period: Period
 }
 
 export const DT_FULL = {
@@ -44,30 +52,56 @@ export const DT_FULL = {
   hour12: true,
 } as DateTimeFormatOptions
 
-export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRange {
+export function getPeriodUKDateTimeRange(period: unknown): DateTimeRange {
+  if (!isValidPeriod(period)) {
+    // today
+    return {
+      start: TimeConstants.TODAY,
+      end: TimeConstants.END_OF_TODAY,
+      valid: false,
+      period: Period.TODAY,
+    }
+  }
+
   switch (period) {
+    case 'today':
+      return {
+        start: TimeConstants.TODAY,
+        end: TimeConstants.END_OF_TODAY,
+        valid: true,
+        period: Period.TODAY,
+      }
+
     case 'yesterday':
       return {
         start: TimeConstants.YESTERDAY,
         end: TimeConstants.YESTERDAY.endOf('day'),
+        valid: true,
+        period: Period.YESTERDAY,
       }
 
     case 'previous-seven-days':
       return {
         start: TimeConstants.SEVEN_DAYS_AGO,
         end: TimeConstants.END_OF_YESTERDAY,
+        valid: true,
+        period: Period.PREVIOUS_SEVEN_DAYS,
       }
 
     case 'previous-thirty-days':
       return {
         start: TimeConstants.THIRTY_DAYS_AGO,
         end: TimeConstants.END_OF_YESTERDAY,
+        valid: true,
+        period: Period.PREVIOUS_THIRTY_DAYS,
       }
 
     case 'previous-month': {
       return {
         start: TimeConstants.START_OF_LAST_MONTH,
         end: TimeConstants.END_OF_LAST_MONTH,
+        valid: true,
+        period: Period.PREVIOUS_MONTH,
       }
     }
 
@@ -75,6 +109,8 @@ export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRa
       return {
         start: TimeConstants.TWELVE_MONTHS_AGO,
         end: TimeConstants.END_OF_TODAY,
+        valid: true,
+        period: Period.LAST_12_MONTHS,
       }
     }
 
@@ -82,15 +118,10 @@ export function getPeriodUKDateTimeRange(period: Period | undefined): DateTimeRa
       return {
         start: undefined,
         end: undefined,
+        valid: true,
+        period: Period.ALL_TIME,
       }
     }
-
-    default:
-      // today
-      return {
-        start: TimeConstants.TODAY,
-        end: TimeConstants.END_OF_TODAY,
-      }
   }
 }
 

--- a/src/utils/types/non-empty-string.ts
+++ b/src/utils/types/non-empty-string.ts
@@ -1,0 +1,15 @@
+export type NonEmptyString = string & {
+  __brand: 'non empty string'
+}
+
+export function nonEmpty(value: unknown): NonEmptyString | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  return value === '' ? undefined : (value as NonEmptyString)
+}
+
+export function nonEmptyStringArray(array: unknown[]): NonEmptyString[] {
+  return array.map(nonEmpty).filter((maybeString) => maybeString !== undefined)
+}

--- a/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
+++ b/test/cypress/integration/simplified-account/agreements/agreements.cy.ts
@@ -205,6 +205,11 @@ describe('Agreements', () => {
     cy.get('[data-cy="transaction-list-title"]').should('contain', 'Transactions')
     cy.get('#transactions-list').should('exist')
     cy.get('[data-cy="all-payment-link"]').should('exist')
+    cy.get('[data-cy="all-payment-link"] > a').should(
+      'have.attr',
+      'href',
+      `/service/${SERVICE_EXTERNAL_ID}/account/${GatewayAccountType.TEST}/transactions?agreementId=a-valid-agreement-id`
+    )
 
     cy.log('Navigate back using back link and verify filters are persisted')
     cy.get('.govuk-back-link').click()


### PR DESCRIPTION
## What

PP-15481

 - Fixes the "Show all transactions for this agreement" link on the Agreement detail page to link to the new Transactions list, filtering on the agreement ID
   - adds a check for this in Cypress test
 - this also tightens up the validation of the transaction search significantly, sanitising all values
   - this should possibly be abstracted to a validator using `express-validator`. this can be done in the future

n.b. because there is no agreement ID filter on the Transactions page, the user cannot filter for this themselves, and so it is not possible to search by agreement ID with any filters other than the default "last 12 months" date filter. We should consider adding the ability to filter by agreement ID, possibly as an additional advanced filter.
