### PR TITLE
PP-15481 Require authorisation before redirecting on All Service Transactions routes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -178,35 +178,35 @@ module.exports.bind = function (app) {
   // All service transactions
   app.get(
     allServiceTransactions.index,
-    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
     userIsAuthorised,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
     allTransactionsController.getController
   )
   app.get(
     allServiceTransactions.indexStatusFilter,
     validateStatusFilter,
-    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
     userIsAuthorised,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.index),
     allTransactionsController.getController
   )
   app.get(
     allServiceTransactions.indexStatusFilterWithoutSearch,
     validateStatusFilter,
-    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.nosearch),
     userIsAuthorised,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.nosearch),
     allTransactionsController.noAutosearchTransactions
   )
   app.get(
     allServiceTransactions.download,
-    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
     userIsAuthorised,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
     allTransactionsController.downloadTransactions
   )
   app.get(
     allServiceTransactions.downloadStatusFilter,
     validateStatusFilter,
-    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
     userIsAuthorised,
+    allServiceTransactionRedirect(paths.allServiceTransactions.simplifiedAccount.download),
     allTransactionsController.downloadTransactions
   )
   app.get(

--- a/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
+++ b/test/cypress/integration/all-service-transactions/all-service-transactions-no-autosearch.cy.js
@@ -58,6 +58,10 @@ const testTransactions = [
 ]
 
 describe('All service transactions without automatic search', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(userExternalId)
+  })
+
   describe('redirect', () => {
     it('should redirect to the new pages for /test', () => {
       cy.task('setupStubs', [
@@ -109,10 +113,6 @@ describe('All service transactions without automatic search', () => {
   })
 
   describe.skip('skipping old tests', () => {
-    beforeEach(() => {
-      cy.setEncryptedCookies(userExternalId)
-    })
-
     it('should display All Service Transactions list page with no live transactions and ability to view test transactions', () => {
       cy.task('setupStubs', [
         userStub,


### PR DESCRIPTION
## What

PP-15481

- change middleware order on old All Service Transactions routes to require user to be logged in before redirecting to new pages
- this is not a significant change, since the user would always be redirected to a route requiring authorisation, however this saves serving unnecessary requests where the user is not authorised 