### PR TITLE
PP-15481 Set default date filter in Transactions search to 'all time'

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -46,7 +46,7 @@ async function get(
 
   const isStripe = req.viewMode.paymentProviders.includes(PaymentProviders.STRIPE)
   const transactionSearchParams = TransactionSearchParams.Builder(req.viewMode.gatewayAccountIds)
-    .withDefaultDateFilter(Period.LAST_12_MONTHS)
+    .withDefaultDateFilter(Period.ALL_TIME)
     .withPagination(MAX_TRANSACTIONS_PER_PAGE)
     .withSearchQuery(req.query)
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -30,7 +30,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const isStripe = req.account.paymentProvider === 'stripe'
   const gatewayAccountId = req.account.id
   const transactionSearchParams = TransactionSearchParams.Builder(gatewayAccountId)
-    .withDefaultDateFilter(Period.LAST_12_MONTHS)
+    .withDefaultDateFilter(Period.ALL_TIME)
     .withPagination(MAX_TRANSACTIONS_PER_PAGE)
     .withSearchQuery(req.query)
 

--- a/src/models/transaction/TransactionSearchParams.test.ts
+++ b/src/models/transaction/TransactionSearchParams.test.ts
@@ -61,6 +61,18 @@ describe('Transaction search params tests', () => {
     )
   })
 
+  it('allow setting the default date params to all time', () => {
+    const testGatewayAccountId = 1
+    const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withDefaultDateFilter(Period.ALL_TIME)
+
+    const ledgerQuery = searchParams.toJson()
+    expect(ledgerQuery.from_date).to.be.undefined
+    expect(ledgerQuery.to_date).to.be.undefined
+
+    const queryString = ledgerQuery.asQueryString()
+    queryString.should.eq(`account_id=1`)
+  })
+
   it('should allow setting pagination', () => {
     const testGatewayAccountId = 1
     const searchParams = TransactionSearchParams.Builder(testGatewayAccountId).withPagination(20).withSearchQuery({})

--- a/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
+++ b/test/cypress/integration/make-a-demo-payment/go-to-transactions.cy.js
@@ -42,10 +42,7 @@ const setupStubs = (options = {}) => {
     transactionStubs.getLedgerTransactionsSuccess({
       gatewayAccountId: GATEWAY_ACCOUNT_ID,
       displaySize: 20,
-      filters: {
-        from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-        to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-      },
+      filters: {},
       transactionLength: 1,
     }),
     gatewayAccountStubs.getCardTypesSuccess(),

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
@@ -1,7 +1,6 @@
 import userStubs from '@test/cypress/stubs/user-stubs'
 import GatewayAccountType, { TEST } from '@models/gateway-account/gateway-account-type'
 import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/gateway-account-stubs'
-import transactionStubs from '@test/cypress/stubs/transaction-stubs'
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import {
   getTransactionEvents,
@@ -10,7 +9,6 @@ import {
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import ROLES from '@test/fixtures/roles.fixtures'
 import { DateTime } from 'luxon'
-import { TimeConstants } from '@utils/time/time-constants'
 
 const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
 const TRANSACTION = new TransactionFixture({
@@ -65,13 +63,6 @@ describe('All services transaction details page', () => {
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
       getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
       getCardTypesSuccess(),
-      transactionStubs.getLedgerTransactionsSuccess({
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-        transactions: [TRANSACTION],
-        filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
-        displaySize: 20,
-        transactionLength: 1,
-      }),
     ])
   })
 

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-list.cy.ts
@@ -10,6 +10,7 @@ import { TransactionSearchParams } from '@models/transaction/TransactionSearchPa
 import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
 import { searchByServiceExternalIds } from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import PaymentProviders from '@models/constants/payment-providers'
+import { Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
 
 const USER_EXTERNAL_ID = 'user123abc'
 const USER_EMAIL = 's.mcduck@example.com'
@@ -81,7 +82,7 @@ describe('All Service Transactions list', () => {
         searchTransactions(
           TransactionSearchParams.Builder(accountIds)
             .withPagination(20)
-            .withDefaultDateFilter('last-12-months')
+            .withDefaultDateFilter(Period.ALL_TIME)
             .withSearchQuery({})
         ).success([STRIPE_TRANSACTION, WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([
@@ -155,7 +156,7 @@ describe('All Service Transactions list', () => {
         searchTransactions(
           TransactionSearchParams.Builder(accountIds)
             .withPagination(20)
-            .withDefaultDateFilter('last-12-months')
+            .withDefaultDateFilter(Period.ALL_TIME)
             .withSearchQuery({})
         ).success([WORLDPAY_TRANSACTION, SANDBOX_TRANSACTION]),
         searchByServiceExternalIds([SANDBOX_SERVICE.externalId, WORLDPAY_SERVICE.externalId]).success([

--- a/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
+++ b/test/cypress/integration/simplified-account/transaction/transaction-index.cy.ts
@@ -12,7 +12,6 @@ import { TransactionStateFixture } from '@test/fixtures/transaction/transaction-
 import { getTransactionsForGatewayAccount } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import { PaymentDetailsFixture } from '@test/fixtures/transaction/payment-details.fixture'
 import { getLedgerTransactionsFailure, getLedgerTransactionsSuccess } from '@test/cypress/stubs/transaction-stubs'
-import { TimeConstants } from '@utils/time/time-constants'
 import { CardDetailsFixture } from '@test/fixtures/card-details/card-details.fixture'
 import {
   DISPUTE_LOST_DATA,
@@ -136,10 +135,7 @@ describe('Transactions index', () => {
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
           transactionLength: 6000,
-          filters: {
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-          },
+          filters: {},
           displaySize: 20,
         }),
       ])
@@ -160,8 +156,6 @@ describe('Transactions index', () => {
           transactionLength: 6000,
           filters: {
             reference: 'unfiltered',
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
           },
           displaySize: 20,
         }),
@@ -617,10 +611,7 @@ describe('Transactions index', () => {
           {
             gatewayAccountId: GATEWAY_ACCOUNT_ID,
             transactions: [TRANSACTION],
-            filters: {
-              from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-              to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-            },
+            filters: {},
             displaySize: 20,
             transactionLength: 1,
           },
@@ -648,10 +639,7 @@ describe('Transactions index', () => {
           {
             gatewayAccountId: GATEWAY_ACCOUNT_ID,
             transactions: [TRANSACTION],
-            filters: {
-              from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-              to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-            },
+            filters: {},
             displaySize: 20,
             transactionLength: 1,
           },
@@ -679,10 +667,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: {
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-          },
+          filters: {},
           displaySize: 20,
           transactionLength: 50,
         }),
@@ -733,10 +718,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: {
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-          },
+          filters: {},
           displaySize: 20,
           transactionLength: 100,
           page: 3,
@@ -775,10 +757,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: {
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-          },
+          filters: {},
           displaySize: 20,
           transactionLength: 100,
           page: 5,
@@ -808,10 +787,7 @@ describe('Transactions index', () => {
         getLedgerTransactionsSuccess({
           gatewayAccountId: GATEWAY_ACCOUNT_ID,
           transactions: [TRANSACTION],
-          filters: {
-            from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-            to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-          },
+          filters: {},
           displaySize: 20,
           transactionLength: 10,
           page: 1,
@@ -839,8 +815,6 @@ describe('Transactions index', () => {
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
         filters: {
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
           reference,
           email,
           cardholder_name: cardholderNameSearchParam,
@@ -881,10 +855,7 @@ describe('Transactions index', () => {
       const ledgerTransactionsParams = {
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
-        filters: {
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
-        },
+        filters: {},
         displaySize: 20,
         transactionLength: 6000,
       }
@@ -930,8 +901,6 @@ describe('Transactions index', () => {
         gatewayAccountId: GATEWAY_ACCOUNT_ID,
         transactions: [TRANSACTION],
         filters: {
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
           reference,
           email,
           cardholder_name: cardholderNameSearchParam,

--- a/test/cypress/stubs/simplified-account/transaction-stubs.ts
+++ b/test/cypress/stubs/simplified-account/transaction-stubs.ts
@@ -4,7 +4,6 @@ import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixtu
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import refundFixtures from '@test/fixtures/refund.fixtures'
 import { TransactionData } from '@models/transaction/dto/Transaction.dto'
-import { TimeConstants } from '@utils/time/time-constants'
 import { TransactionSearchParams } from '@models/transaction/TransactionSearchParams.class'
 
 function getTransaction(transactionExternalId: string) {
@@ -55,8 +54,6 @@ function getTransactionsForGatewayAccount(gatewayAccountId: string) {
           display_size: 20,
           limit_total: true,
           limit_total_size: 5001,
-          from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO(),
-          to_date: TimeConstants.END_OF_TODAY.toUTC().toISO(),
         },
       })
     },


### PR DESCRIPTION
## What

PP-15481

 - set the default date filter in Transactions list and All Service Transactions list to `all-time`
 - this shows as "Show all" in the dropdown list, with the from date and to date fields empty