### PR TITLE
PP-15379 fix double service name error message

### DIFF
--- a/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
+++ b/src/controllers/simplified-account/settings/service-name/edit/edit-service-name.controller.ts
@@ -51,23 +51,12 @@ async function post(req: ServiceRequest<EditServiceNameBody>, res: ServiceRespon
       .bail()
       .unescape()
       .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-      .withMessage('You cannot use any of the following characters < > | in the service name'),
+      .withMessage('You cannot use any of the following characters < > | in the service name')
+      .bail(),
   ]
   // we don't check presence for welsh names
   if (!editCy) {
-    validations.push(
-      body('serviceName')
-        .trim()
-        .isLength({ max: SERVICE_NAME_MAX_LENGTH })
-        .withMessage(`Service name must be ${SERVICE_NAME_MAX_LENGTH} characters or fewer`)
-        .bail()
-        .unescape()
-        .matches(/^[^<>|]*$/) // no '<' or '>' or '|' characters
-        .withMessage('You cannot use any of the following characters < > | in the service name')
-        .bail()
-        .notEmpty()
-        .withMessage('Service name is required')
-    )
+    validations.push(body('serviceName').notEmpty().withMessage('Service name is required'))
   }
 
   await Promise.all(validations.map((validation) => validation.run(req)))


### PR DESCRIPTION
## What

When editing service name and entering a service name that is greater than 50 characters the error message appear twice.

Fix the bug so the message only appears once.

PP-15379


### How
_Steps to test or reproduce_

### Accessibility (views have been added/changed)

N/A

### Screenshots (views have been added/changed)

<img width="767" height="553" alt="Screenshot 2026-07-14 at 12 09 34" src="https://github.com/user-attachments/assets/fadc963a-3f87-43a4-8b52-76e48401a88b" />

