### PR TITLE
PP-15611 Fix All Service Transactions nosearch page searching on wrong route

### DIFF
--- a/src/views/simplified-account/services/transactions/list/partials/_search-form.njk
+++ b/src/views/simplified-account/services/transactions/list/partials/_search-form.njk
@@ -1,4 +1,4 @@
-<form method="GET" novalidate autocomplete="off">
+<form method="GET" novalidate autocomplete="off" {% if searchLink %}action="{{ searchLink }}"{% endif %}>
   {% include "./_filter.njk" %}
 
 

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-nosearch.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-nosearch.cy.ts
@@ -1,0 +1,231 @@
+import userStubs from '@test/cypress/stubs/user-stubs'
+import gatewayAccountStubs, { getCardTypesSuccess } from '@test/cypress/stubs/gateway-account-stubs'
+import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixture'
+import { LIVE, TEST } from '@models/gateway-account/gateway-account-type'
+import {
+  getTransactionForGatewayAccount,
+  getTransactionsForGatewayAccount,
+} from '@test/cypress/stubs/simplified-account/transaction-stubs'
+import { DateTime } from 'luxon'
+
+const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
+const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
+
+const USER_EXTERNAL_ID = 'user123abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_GATEWAY_ACCOUNT_ID = '1'
+const TEST_GATEWAY_ACCOUNT_ID = '2'
+const SERVICE_NAME = {
+  en: 'McDuck Enterprises',
+  cy: 'Mentrau McDuck',
+}
+const USER_EMAIL = 's.mcduck@example.com'
+
+const TEST_TRANSACTIONS_LIST_URL = `/transactions/${TEST}`
+const LIVE_TRANSACTIONS_LIST_URL = `/transactions/${LIVE}`
+
+const HEADING_SUFFIX = 'transactions: all services'
+
+describe('All service transactions nosearch page', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+    cy.task('setupStubs', [
+      getTransactionForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
+      getCardTypesSuccess(),
+      userStubs.getUserSuccess({
+        userExternalId: USER_EXTERNAL_ID,
+        email: USER_EMAIL,
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+        serviceName: SERVICE_NAME,
+      }),
+    ])
+  })
+
+  describe('Live page content', () => {
+    it('accessibility check', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit(LIVE_TRANSACTIONS_LIST_URL)
+      cy.a11yCheck()
+    })
+
+    it('should display correct page title and heading', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/live/nosearch')
+
+      const heading = `Live ${HEADING_SUFFIX}`
+
+      cy.title().should('eq', `${heading} - GOV.UK Pay`)
+      cy.get('h1').should('contain.text', heading)
+    })
+
+    it('should not show link to test mode if no test accounts exist', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/live/nosearch')
+
+      cy.contains('a.govuk-link', 'View test transactions').should('not.exist')
+    })
+
+    it('should navigate to test transactions', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        getTransactionsForGatewayAccount(TEST_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: TEST,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE, TEST],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/live/nosearch')
+
+      cy.contains('a.govuk-link', 'View test transactions').should('be.visible').click()
+      cy.get('h1').should('contain.text', `Test ${HEADING_SUFFIX}`)
+      cy.url().should('include', '/transactions/test')
+    })
+
+    it('should search on the standard search page', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/live/nosearch')
+
+      cy.contains('Search transactions').click()
+
+      cy.location('pathname').should('eq', '/transactions/live')
+
+      cy.get('table#transactions-list').within(() => {
+        cy.get('thead > tr').within(() => {
+          cy.get('th').eq(0).should('contain.text', 'Reference number')
+          cy.get('th').eq(1).should('contain.text', 'Email')
+          cy.get('th').eq(2).should('contain.text', 'Amount')
+          cy.get('th').eq(3).should('contain.text', 'Card brand')
+          cy.get('th').eq(4).should('contain.text', 'Payment Status')
+          cy.get('th').eq(5).should('contain.text', 'Date created')
+        })
+      })
+
+      cy.get('tbody > tr')
+        .eq(0)
+        .within(() => {
+          cy.get('th').eq(0).should('contain.text', 'transaction-reference')
+          cy.get('td').eq(0).should('contain.text', 'test2@example.org')
+          cy.get('td').eq(1).should('contain.text', '£10.00')
+          cy.get('td').eq(2).should('contain.text', 'Visa')
+          cy.get('td').eq(3).should('contain.text', 'Success')
+        })
+    })
+  })
+
+  describe('Test page content', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        userStubs.getUserSuccess({
+          userExternalId: USER_EXTERNAL_ID,
+          email: USER_EMAIL,
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+          serviceName: SERVICE_NAME,
+        }),
+        getTransactionsForGatewayAccount(TEST_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: TEST,
+          gatewayAccountId: TEST_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+    })
+
+    it('accessibility check', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/test/nosearch')
+      cy.a11yCheck()
+    })
+
+    it('should display correct page title and headings', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/test/nosearch')
+      const heading = `Test ${HEADING_SUFFIX}`
+
+      cy.title().should('eq', `${heading} - GOV.UK Pay`)
+      cy.get('h1').should('contain.text', heading)
+    })
+
+    it('should not show link to live mode if no live accounts exist', () => {
+      cy.task('setupStubs', [
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [TEST],
+          gatewayAccountIds: [TEST_GATEWAY_ACCOUNT_ID],
+        }),
+      ])
+      cy.visit('/transactions/test/nosearch')
+
+      cy.contains('a.govuk-link', 'View live transactions').should('not.exist')
+      cy.url().should('include', TEST_TRANSACTIONS_LIST_URL)
+    })
+
+    it('should navigate to live transactions', () => {
+      cy.task('setupStubs', [
+        getTransactionsForGatewayAccount(LIVE_GATEWAY_ACCOUNT_ID).success([TRANSACTION.toTransactionData()]),
+        gatewayAccountStubs.getGatewayAccountsByServiceIdAndTypeSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          types: [LIVE, TEST],
+          gatewayAccountIds: [LIVE_GATEWAY_ACCOUNT_ID, TEST_GATEWAY_ACCOUNT_ID],
+        }),
+        gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+          serviceExternalId: SERVICE_EXTERNAL_ID,
+          type: LIVE,
+          gatewayAccountId: LIVE_GATEWAY_ACCOUNT_ID,
+        }),
+      ])
+      cy.visit('/transactions/test/nosearch')
+
+      cy.contains('a.govuk-link', 'View live transactions').should('be.visible').click()
+      cy.get('h1').should('contain.text', `Live ${HEADING_SUFFIX}`)
+      cy.url().should('include', '/transactions/live')
+    })
+  })
+})


### PR DESCRIPTION
## What

PP-15611
Refactoring in #4977 inadvertently removed the modified search URL on the All Service Transactions nosearch page, meaning that submitting the form would send the request on the `/nosearch` URL, which does not perform the search. This meant that when a search timed out, the user would not be able to refine the search.

This fixes this bug by conditionally adding an `action` attribute to the `<form>` element if a `searchLink` property is present in the nunjucks template

This also adds Cypress tests for the nosearch page, verifying that is searches on the correct URL