### PR TITLE
PP-15660 Fix Duplicate Refunds Issue

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/refund/all-service-transactions-refund.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/refund/all-service-transactions-refund.controller.ts
@@ -11,6 +11,7 @@ import { ChargeRefundRequest } from '@models/charge/ChargeRefundRequest.class'
 import { safeConvertPoundsStringToPence } from '@utils/currency-formatter'
 import { Message } from '@utils/types/express/Message'
 import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
+import { InvalidRefundAmountAvailableError } from '@root/errors'
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
   req.serviceView.showHeader = false
@@ -42,6 +43,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
 interface TransactionRefundBody {
   refundPayment: string
   partialRefundAmount: string
+  refundAmountAvailable: string
 }
 
 async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResponse) {
@@ -83,14 +85,21 @@ async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResp
     })
   }
 
+  // this is provided from the refund form as an idempotency check
+  const refundAmountAvailable = parseInt(req.body.refundAmountAvailable)
+  if (isNaN(refundAmountAvailable)) {
+    throw new InvalidRefundAmountAvailableError(
+      `Unable to parse refund amount available value ${req.body.refundAmountAvailable} in refund form submission`
+    )
+  }
+
   const refundAmount =
     req.body.refundPayment === 'full'
-      ? transaction.refundSummary!.amountAvailable
+      ? refundAmountAvailable
       : safeConvertPoundsStringToPence(req.body.partialRefundAmount)
   if (refundAmount === undefined || refundAmount === null) {
     throw new Error(`Attempting to issue ${req.body.refundPayment} refund with undefined or null value`)
   }
-  const refundAmountAvailable = transaction.refundSummary!.amountAvailable
 
   await submitRefund(
     req.service.externalId,

--- a/src/controllers/simplified-account/services/transactions/refund/transaction-refund.controller.test.ts
+++ b/src/controllers/simplified-account/services/transactions/refund/transaction-refund.controller.test.ts
@@ -334,6 +334,7 @@ describe('transaction refund controller', () => {
             body: {
               refundPayment: 'full',
               partialRefundAmount: '',
+              refundAmountAvailable: '1000',
             },
           })
           getTransactionStub.resolves(transactionFixture.toTransaction())
@@ -377,6 +378,7 @@ describe('transaction refund controller', () => {
             body: {
               refundPayment: 'full',
               partialRefundAmount: '',
+              refundAmountAvailable: '300',
             },
           })
           getTransactionStub.resolves(partiallyRefundedTransaction.toTransaction())
@@ -404,6 +406,7 @@ describe('transaction refund controller', () => {
             body: {
               refundPayment: 'partial',
               partialRefundAmount: '2.50',
+              refundAmountAvailable: '300',
             },
           })
           getTransactionStub.resolves(partiallyRefundedTransaction.toTransaction())

--- a/src/controllers/simplified-account/services/transactions/refund/transaction-refund.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/refund/transaction-refund.controller.ts
@@ -11,6 +11,7 @@ import { ChargeRefundRequest } from '@models/charge/ChargeRefundRequest.class'
 import { safeConvertPoundsStringToPence } from '@utils/currency-formatter'
 import { Message } from '@utils/types/express/Message'
 import { TITLE_FRIENDLY_DATE_TIME } from '@models/constants/time-formats'
+import { InvalidRefundAmountAvailableError } from '@root/errors'
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
   const transaction = await getTransaction(req.params.transactionExternalId, req.account.id)
@@ -40,6 +41,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
 interface TransactionRefundBody {
   refundPayment: string
   partialRefundAmount: string
+  refundAmountAvailable: string
 }
 
 async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResponse) {
@@ -80,15 +82,22 @@ async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResp
       partialRefundAmount: req.body.partialRefundAmount,
     })
   }
+  // this is provided from the refund form as an idempotency check
+  const refundAmountAvailable = parseInt(req.body.refundAmountAvailable)
+  if (isNaN(refundAmountAvailable)) {
+    throw new InvalidRefundAmountAvailableError(
+      `Unable to parse refund amount available value ${req.body.refundAmountAvailable} in refund form submission`
+    )
+  }
 
   const refundAmount =
     req.body.refundPayment === 'full'
-      ? transaction.refundSummary!.amountAvailable
+      ? refundAmountAvailable
       : safeConvertPoundsStringToPence(req.body.partialRefundAmount)
+
   if (refundAmount === undefined || refundAmount === null) {
     throw new Error(`Attempting to issue ${req.body.refundPayment} refund with undefined or null value`)
   }
-  const refundAmountAvailable = transaction.refundSummary!.amountAvailable
 
   await submitRefund(
     req.service.externalId,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,6 +105,8 @@ class TaskAccessedOutOfSequenceError extends DomainError {
   }
 }
 
+class InvalidRefundAmountAvailableError extends DomainError {}
+
 export {
   NotAuthenticatedError,
   UserAccountDisabledError,
@@ -120,4 +122,5 @@ export {
   GatewayTimeoutForAllServicesSearchError,
   TaskAlreadyCompletedError,
   TaskAccessedOutOfSequenceError,
+  InvalidRefundAmountAvailableError,
 }

--- a/src/views/simplified-account/services/all-service-transactions/detail/refund.njk
+++ b/src/views/simplified-account/services/all-service-transactions/detail/refund.njk
@@ -38,6 +38,12 @@
 {% block serviceContent %}
   <form method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+    <input
+      id="refund-amount-available"
+      name="refundAmountAvailable"
+      type="hidden"
+      value="{{ transaction.getRefundableAmountRemaining() }}"
+    />
 
     {{
       govukRadios({
@@ -76,7 +82,8 @@
 
     {{
       govukButton({
-        text: "Confirm refund"
+        text: "Confirm refund",
+        preventDoubleClick: true
       })
     }}
   </form>

--- a/src/views/simplified-account/services/transactions/refund/transaction-refund.njk
+++ b/src/views/simplified-account/services/transactions/refund/transaction-refund.njk
@@ -36,6 +36,12 @@
 {% block serviceContent %}
   <form method="post">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+    <input
+      id="refund-amount-available"
+      name="refundAmountAvailable"
+      type="hidden"
+      value="{{ transaction.getRefundableAmountRemaining() }}"
+    />
 
     {{
       govukRadios({
@@ -74,7 +80,8 @@
 
     {{
       govukButton({
-        text: "Confirm refund"
+        text: "Confirm refund",
+        preventDoubleClick: true
       })
     }}
   </form>

--- a/test/cypress/integration/simplified-account/transactions/transaction-refund/transaction-refund.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-refund/transaction-refund.cy.ts
@@ -279,4 +279,71 @@ describe('Refund page', () => {
       .should('contain.text', errorMessage)
     cy.get('.govuk-error-message').should('exist').should('contain.text', errorMessage)
   })
+
+  it('should call the submit refund endpoint with the value of the refundAmountAvailable hidden field, not the value on the transaction', () => {
+    const baseTransaction = new TransactionFixture({
+      createdDate: TRANSACTION_CREATED_TIMESTAMP,
+      amount: 1000,
+      externalId: 'this-is-the-same-transaction-in-both-cases',
+      refundSummary: new LedgerRefundSummaryFixture({
+        amountAvailable: 1000,
+        status: 'available',
+        amountRefunded: 0,
+        amountSubmitted: 0,
+        userExternalId: null,
+      }),
+    })
+
+    const partiallyRefundedTransaction = new TransactionFixture({
+      createdDate: TRANSACTION_CREATED_TIMESTAMP,
+      amount: 1000,
+      externalId: 'this-is-the-same-transaction-in-both-cases',
+      refundSummary: new LedgerRefundSummaryFixture({
+        amountAvailable: 700,
+        status: 'available',
+        amountRefunded: 300,
+        amountSubmitted: 0,
+        userExternalId: USER_EXTERNAL_ID,
+      }),
+    })
+
+    cy.task('setupStubs', [
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, baseTransaction.externalId).success(baseTransaction),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, baseTransaction.externalId).success([]),
+    ])
+
+    cy.visit(
+      `/service/${SERVICE_EXTERNAL_ID}/account/test/transactions/this-is-the-same-transaction-in-both-cases/refund`
+    )
+
+    // simulate a partial refund being issued on the Transaction while the user is on the refund page
+    // the Transaction retrieved from Ledger updates, but the controller should use the refund_amount_available value
+    // from the original unrefunded Transaction when attempting to submit the refund
+    cy.task('clearStubs')
+    cy.task('setupStubs', [
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, partiallyRefundedTransaction.externalId).success(
+        partiallyRefundedTransaction
+      ),
+      postRefund(SERVICE_EXTERNAL_ID, baseTransaction.externalId).success(
+        1000,
+        baseTransaction,
+        USER_EXTERNAL_ID,
+        USER_EMAIL
+      ),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, partiallyRefundedTransaction.externalId).success([]),
+      ...userAndGatewayAccountStubs,
+    ])
+
+    cy.get('#refund-payment').check()
+    cy.contains('Confirm refund').click()
+
+    cy.get('.govuk-notification-banner--success')
+      .should('be.visible')
+      .and('contain', 'Refund successful')
+      .and('contain', 'It may take up to six days to process')
+    cy.url().should(
+      'include',
+      `/service/${SERVICE_EXTERNAL_ID}/account/test/transactions/this-is-the-same-transaction-in-both-cases`
+    )
+  })
 })


### PR DESCRIPTION
## What

PP-15660

Fix several issues with refund submissions which could lead to duplicate refunds being submitted
- fix missing `preventDoubleClick` attribute on submit button
- embed refund amount available as hidden field in refund form, use this value for submitting the refund to Connector instead of the value on the charge
  - this prevents duplicate refunds being submitted as the amount available would not be correct on duplicates
- fix full refund submissions to use the embedded amount available for the amount to refund
- add Cypress test to cover mismatched refund amount available values in form submission and Transaction data