### PR TITLE
PP-15686 Enable Adyen PSP selection via service feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,17 @@ This command will run all [mocha](https://mochajs.org/) test suites matching the
 To run Cypress tests start the server in a separate terminal
 
 ```bash
+npm run compile
+```
+
+```bash
 npm run cypress:server
+```
+
+If you are making changes to the codebase then the dev-server command will watch for any changes made and rebuild the app 
+
+```bash
+npm run cypress:dev-server
 ```
 
 _This runs both the Cypress server and @govuk-pay/run-amock which is the mock server used for stubbing out external API

--- a/package-lock.json
+++ b/package-lock.json
@@ -3954,9 +3954,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3971,9 +3968,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3988,9 +3982,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4005,9 +3996,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4323,9 +4311,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4347,9 +4332,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4371,9 +4353,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4395,9 +4374,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4419,9 +4395,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4443,9 +4416,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16139,7 +16109,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16158,7 +16127,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16177,7 +16145,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16196,7 +16163,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16215,7 +16181,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16234,7 +16199,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16253,7 +16217,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16272,7 +16235,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/controllers/request-to-go-live/agreement/get.controller.js
+++ b/src/controllers/request-to-go-live/agreement/get.controller.js
@@ -16,11 +16,11 @@ module.exports = (req, res) => {
   if (chosenOptions.includes(req.service.currentGoLiveStage)) {
     let currentGoLiveStage = lodash.get(req, 'service.currentGoLiveStage', '')
 
-    const isAdyenEnabled = Features.isAdyenEnabledInGoLiveRequest() ||
-    Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+    const isAdyenEnabled =
+      Features.isAdyenEnabledInGoLiveRequest() || Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
 
     return response(req, res, 'request-to-go-live/agreement', {
-      displayAdyenPspAgreement: (currentGoLiveStage === goLiveStage.CHOSEN_PSP_ADYEN) && isAdyenEnabled,
+      displayAdyenPspAgreement: currentGoLiveStage === goLiveStage.CHOSEN_PSP_ADYEN && isAdyenEnabled,
       displayStripePspAgreement: currentGoLiveStage === goLiveStage.CHOSEN_PSP_STRIPE,
     })
   }

--- a/src/controllers/request-to-go-live/agreement/get.controller.js
+++ b/src/controllers/request-to-go-live/agreement/get.controller.js
@@ -1,5 +1,7 @@
 'use strict'
 
+import { Features } from '@root/config/features'
+
 const lodash = require('lodash')
 
 const goLiveStage = require('@models/constants/go-live-stage')
@@ -13,8 +15,12 @@ const chosenOptions = [CHOSEN_PSP_ADYEN, CHOSEN_PSP_STRIPE, GOV_BANKING_MOTO_OPT
 module.exports = (req, res) => {
   if (chosenOptions.includes(req.service.currentGoLiveStage)) {
     let currentGoLiveStage = lodash.get(req, 'service.currentGoLiveStage', '')
+
+    const isAdyenEnabled = Features.isAdyenEnabledInGoLiveRequest() ||
+    Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+
     return response(req, res, 'request-to-go-live/agreement', {
-      displayAdyenPspAgreement: currentGoLiveStage === goLiveStage.CHOSEN_PSP_ADYEN,
+      displayAdyenPspAgreement: (currentGoLiveStage === goLiveStage.CHOSEN_PSP_ADYEN) && isAdyenEnabled,
       displayStripePspAgreement: currentGoLiveStage === goLiveStage.CHOSEN_PSP_STRIPE,
     })
   }

--- a/src/controllers/request-to-go-live/agreement/get.controller.js
+++ b/src/controllers/request-to-go-live/agreement/get.controller.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
     let currentGoLiveStage = lodash.get(req, 'service.currentGoLiveStage', '')
 
     const isAdyenEnabled =
-      Features.isAdyenEnabledInGoLiveRequest() || Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+      Features.isAdyenEnabledInGoLiveRequest() || req?.service?.serviceFeatures?.govuk_psp_is_adyen?.enabled
 
     return response(req, res, 'request-to-go-live/agreement', {
       displayAdyenPspAgreement: currentGoLiveStage === goLiveStage.CHOSEN_PSP_ADYEN && isAdyenEnabled,

--- a/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
+++ b/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
@@ -1,5 +1,7 @@
 'use strict'
 
+import { Features } from '@root/config/features'
+
 const goLiveStage = require('@models/constants/go-live-stage')
 const paths = require('../../../paths')
 const response = require('../../../utils/response')
@@ -13,5 +15,8 @@ module.exports = (req, res) => {
       formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId)
     )
   }
-  return response.response(req, res, 'request-to-go-live/choose-how-to-process-payments')
+  const isAdyenEnabled = Features.isAdyenEnabledInGoLiveRequest() || 
+  Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+
+  return response.response(req, res, 'request-to-go-live/choose-how-to-process-payments', {isAdyenEnabled})
 }

--- a/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
+++ b/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
@@ -13,7 +13,7 @@ module.exports = (req, res) => {
     return res.redirect(303, formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId))
   }
   const isAdyenEnabled =
-    Features.isAdyenEnabledInGoLiveRequest() || Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+    Features.isAdyenEnabledInGoLiveRequest() || req?.service?.serviceFeatures?.govuk_psp_is_adyen?.enabled
 
   return response.response(req, res, 'request-to-go-live/choose-how-to-process-payments', { isAdyenEnabled })
 }

--- a/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
+++ b/src/controllers/request-to-go-live/choose-how-to-process-payments/get.controller.js
@@ -10,13 +10,10 @@ const formatServicePathsFor = require('../../../utils/format-service-paths-for')
 module.exports = (req, res) => {
   // redirect on wrong stage
   if (req.service.currentGoLiveStage !== goLiveStage.ENTERED_ORGANISATION_ADDRESS) {
-    return res.redirect(
-      303,
-      formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId)
-    )
+    return res.redirect(303, formatServicePathsFor(paths.service.requestToGoLive.index, req.service.externalId))
   }
-  const isAdyenEnabled = Features.isAdyenEnabledInGoLiveRequest() || 
-  Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
+  const isAdyenEnabled =
+    Features.isAdyenEnabledInGoLiveRequest() || Boolean(req?.service?.features?.includes('govuk_psp_is_adyen'))
 
-  return response.response(req, res, 'request-to-go-live/choose-how-to-process-payments', {isAdyenEnabled})
+  return response.response(req, res, 'request-to-go-live/choose-how-to-process-payments', { isAdyenEnabled })
 }

--- a/src/models/service/Service.class.ts
+++ b/src/models/service/Service.class.ts
@@ -1,4 +1,4 @@
-import { ServiceData } from '@models/service/dto/Service.dto'
+import { ServiceData, ServiceFeatures } from '@models/service/dto/Service.dto'
 
 class Service {
   readonly id: number
@@ -25,7 +25,7 @@ class Service {
   readonly agentInitiatedMotoEnabled: boolean
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
-  readonly features?: string[]
+  readonly serviceFeatures?: ServiceFeatures
 
   constructor(serviceData: ServiceData) {
     this.id = serviceData.id
@@ -57,7 +57,7 @@ class Service {
     this.agentInitiatedMotoEnabled = serviceData.agent_initiated_moto_enabled
     this.defaultBillingAddressCountry = serviceData.default_billing_address_country
     this.takesPaymentsOverPhone = serviceData.takes_payments_over_phone
-    this.features = serviceData.features
+    this.serviceFeatures = serviceData.service_features
   }
 }
 

--- a/src/models/service/Service.class.ts
+++ b/src/models/service/Service.class.ts
@@ -25,6 +25,7 @@ class Service {
   readonly agentInitiatedMotoEnabled: boolean
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
+  readonly features: string[]
 
   constructor(serviceData: ServiceData) {
     this.id = serviceData.id
@@ -56,6 +57,7 @@ class Service {
     this.agentInitiatedMotoEnabled = serviceData.agent_initiated_moto_enabled
     this.defaultBillingAddressCountry = serviceData.default_billing_address_country
     this.takesPaymentsOverPhone = serviceData.takes_payments_over_phone
+    this.features = serviceData.features || []
   }
 }
 

--- a/src/models/service/Service.class.ts
+++ b/src/models/service/Service.class.ts
@@ -25,7 +25,7 @@ class Service {
   readonly agentInitiatedMotoEnabled: boolean
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
-  readonly features: string[]
+  readonly features?: string[]
 
   constructor(serviceData: ServiceData) {
     this.id = serviceData.id
@@ -57,7 +57,7 @@ class Service {
     this.agentInitiatedMotoEnabled = serviceData.agent_initiated_moto_enabled
     this.defaultBillingAddressCountry = serviceData.default_billing_address_country
     this.takesPaymentsOverPhone = serviceData.takes_payments_over_phone
-    this.features = serviceData.features || []
+    this.features = serviceData.features
   }
 }
 

--- a/src/models/service/Service.class.ts
+++ b/src/models/service/Service.class.ts
@@ -25,7 +25,7 @@ class Service {
   readonly agentInitiatedMotoEnabled: boolean
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
-  readonly serviceFeatures?: ServiceFeatures
+  readonly serviceFeatures: ServiceFeatures
 
   constructor(serviceData: ServiceData) {
     this.id = serviceData.id

--- a/src/models/service/dto/Service.dto.ts
+++ b/src/models/service/dto/Service.dto.ts
@@ -30,5 +30,14 @@ export interface ServiceData {
   agent_initiated_moto_enabled: boolean
   default_billing_address_country?: string
   takes_payments_over_phone: boolean
-  features?: string[]
+  service_features?: ServiceFeatures
+}
+
+export interface ServiceFeature {
+  enabled: boolean
+}
+
+export interface ServiceFeatures {
+  [key: string]: ServiceFeature | undefined
+  govuk_psp_is_adyen?: ServiceFeature
 }

--- a/src/models/service/dto/Service.dto.ts
+++ b/src/models/service/dto/Service.dto.ts
@@ -30,7 +30,7 @@ export interface ServiceData {
   agent_initiated_moto_enabled: boolean
   default_billing_address_country?: string
   takes_payments_over_phone: boolean
-  service_features?: ServiceFeatures
+  service_features: ServiceFeatures
 }
 
 export interface ServiceFeature {

--- a/src/models/service/dto/Service.dto.ts
+++ b/src/models/service/dto/Service.dto.ts
@@ -30,4 +30,5 @@ export interface ServiceData {
   agent_initiated_moto_enabled: boolean
   default_billing_address_country?: string
   takes_payments_over_phone: boolean
+  features?: string[]
 }

--- a/src/views/request-to-go-live/agreement.njk
+++ b/src/views/request-to-go-live/agreement.njk
@@ -30,7 +30,7 @@
         </legend>
         <p class="govuk-body"
           >To use GOV.UK Pay your organisation must accept our legal terms.
-          {% if displayAdyenPspAgreement and EnvironmentFeatures.isAdyenEnabledInGoLiveRequest() %}
+          {% if displayAdyenPspAgreement %}
             These include the legal terms of Adyen, GOV.UK Pay’s payment service provider.
           {% elif displayStripePspAgreement %}
             These include the legal terms of Stripe, GOV.UK Pay’s payment service provider.
@@ -47,7 +47,7 @@
           <li><a href="/policy/contract-for-non-crown-bodies" class="govuk-link">Non-Crown body contract</a></li>
         </ul>
 
-        {% if displayAdyenPspAgreement and EnvironmentFeatures.isAdyenEnabledInGoLiveRequest() %}
+        {% if displayAdyenPspAgreement %}
           {% include './partials/_adyen-legal-terms.njk' %}
         {% elif displayStripePspAgreement %}
           {% include './partials/_stripe-legal-terms.njk' %}

--- a/src/views/request-to-go-live/choose-how-to-process-payments.njk
+++ b/src/views/request-to-go-live/choose-how-to-process-payments.njk
@@ -34,7 +34,7 @@
           hint: {
             text: 'For local authorities, police and government-owned charitable groups. GOV.UK Pay has a contract with Adyen to process payments. Using Adyen means that you do not need your own contract with a payment service provider.'
           }
-        } if EnvironmentFeatures.isAdyenEnabledInGoLiveRequest()
+        } if isAdyenEnabled
       %}
       {{
         govukRadios({

--- a/test/cypress/integration/request-to-go-live/agreement.cy.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.js
@@ -124,7 +124,9 @@ describe('Request to go live: agreement', () => {
 
   describe('Adyen has been chosen as the PSP and service feature is enabled', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_ADYEN', () => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN', 'govuk_psp_is_adyen'))
+      utils.setupGetUserAndGatewayAccountStubs(
+        utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN', 'govuk_psp_is_adyen')
+      )
 
       cy.visit(requestToGoLiveAgreementUrl)
 

--- a/test/cypress/integration/request-to-go-live/agreement.cy.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.js
@@ -61,7 +61,7 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('Stripe has been chosen as the PSP', () => {
+  describe('Stripe has been chosen as the PSP and service feature is disabled', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_STRIPE', () => {
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_STRIPE'))
 
@@ -122,9 +122,9 @@ describe('Request to go live: agreement', () => {
     })
   })
 
-  describe('Adyen has been chosen as the PSP', () => {
+  describe('Adyen has been chosen as the PSP and service feature is enabled', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_ADYEN', () => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN'))
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN', 'govuk_psp_is_adyen'))
 
       cy.visit(requestToGoLiveAgreementUrl)
 

--- a/test/cypress/integration/request-to-go-live/agreement.cy.js
+++ b/test/cypress/integration/request-to-go-live/agreement.cy.js
@@ -124,10 +124,7 @@ describe('Request to go live: agreement', () => {
 
   describe('Adyen has been chosen as the PSP and service feature is enabled', () => {
     it('should display "Read and accept our legal terms" page when in CHOSEN_PSP_ADYEN', () => {
-      utils.setupGetUserAndGatewayAccountStubs(
-        utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN', 'govuk_psp_is_adyen')
-      )
-
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('CHOSEN_PSP_ADYEN', true))
       cy.visit(requestToGoLiveAgreementUrl)
 
       cy.get('h1').should('contain', 'Read and accept our legal terms')

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
@@ -27,8 +27,8 @@ describe('Request to go live: choose how to process payments', () => {
     cy.setEncryptedCookies(userExternalId)
   })
 
-  describe('Service has correct go live stage and user selects Stripe account', () => {
-    it('should allow user to select Stripe', () => {
+  describe('Service has correct go live stage and service feature is disabled', () => {
+    it('should allow user to select Stripe but not Adyen', () => {
       utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
@@ -36,7 +36,7 @@ describe('Request to go live: choose how to process payments', () => {
       cy.get('#request-to-go-live-current-step').should('exist')
       cy.get('#request-to-go-live-choose-how-to-process-payments-form').should('exist')
       cy.get('#choose-how-to-process-payments-mode').should('exist')
-      cy.get('#choose-how-to-process-payments-mode-2').should('exist')
+      cy.get('#choose-how-to-process-payments-mode-2').should('not.exist')
       cy.get('#choose-how-to-process-payments-mode-3').should('exist')
 
       // set up new stubs where the first time we get the service it returns the go_live_stage as ENTERED_ORGANISATION_ADDRESS,
@@ -56,9 +56,9 @@ describe('Request to go live: choose how to process payments', () => {
     })
   })
 
-  describe('Service has correct go live stage and user selects Adyen account', () => {
+  describe('Service has correct go live stage and service feature is enabled', () => {
     it('should allow user to select Adyen', () => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS'))
+      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS', 'govuk_psp_is_adyen'))
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
@@ -59,7 +59,7 @@ describe('Request to go live: choose how to process payments', () => {
   describe('Service has correct go live stage and service feature is enabled', () => {
     it('should allow user to select Adyen', () => {
       utils.setupGetUserAndGatewayAccountStubs(
-        utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS', 'govuk_psp_is_adyen')
+        utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS', true)
       )
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)

--- a/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
+++ b/test/cypress/integration/request-to-go-live/choose-how-to-process-payments.cy.js
@@ -58,7 +58,9 @@ describe('Request to go live: choose how to process payments', () => {
 
   describe('Service has correct go live stage and service feature is enabled', () => {
     it('should allow user to select Adyen', () => {
-      utils.setupGetUserAndGatewayAccountStubs(utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS', 'govuk_psp_is_adyen'))
+      utils.setupGetUserAndGatewayAccountStubs(
+        utils.buildServiceRoleForGoLiveStage('ENTERED_ORGANISATION_ADDRESS', 'govuk_psp_is_adyen')
+      )
 
       cy.visit(requestToGoLiveChooseHowToProcessPaymentUrl)
 

--- a/test/cypress/test.env
+++ b/test/cypress/test.env
@@ -25,4 +25,4 @@ PAYOUTS_RELEASE_DATE=1590148800
 ENABLE_STRIPE_ONBOARDING_TASK_LIST=true
 GOVUK_PAY__USE_BASIC_LOGGER=true
 EXPERIMENTAL_FEATURES_FLAG=true
-EXPERIMENTAL_FEATURES_LIST="transactions,sidebar_nav,provider_change_to_adyen_link,enable_go_live_requests_for_adyen"
+EXPERIMENTAL_FEATURES_LIST="transactions,sidebar_nav,provider_change_to_adyen_link"

--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -11,12 +11,13 @@ const variables = {
   serviceExternalId: 'afe452323dd04d1898672bfaba25e3a6'
 }
 
-function buildServiceRoleForGoLiveStage (goLiveStage) {
+function buildServiceRoleForGoLiveStage (goLiveStage, features) {
   return {
     service: {
       external_id: variables.serviceExternalId,
       current_go_live_stage: goLiveStage,
-      gateway_account_ids: [`${variables.gatewayAccountId}`]
+      gateway_account_ids: [`${variables.gatewayAccountId}`],
+      features: [features]
     }
   }
 }

--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -8,105 +8,104 @@ const variables = {
   userExternalId: 'userExternalId',
   gatewayAccountId: 42,
   gatewayAccountExternalId: 'a-gateway-account-external-id',
-  serviceExternalId: 'afe452323dd04d1898672bfaba25e3a6'
+  serviceExternalId: 'afe452323dd04d1898672bfaba25e3a6',
 }
 
-function buildServiceRoleForGoLiveStage (goLiveStage, features) {
+function buildServiceRoleForGoLiveStage(goLiveStage, features) {
   return {
     service: {
       external_id: variables.serviceExternalId,
       current_go_live_stage: goLiveStage,
       gateway_account_ids: [`${variables.gatewayAccountId}`],
-      features: [features]
-    }
+      features: [features],
+    },
   }
 }
 
-function buildServiceRoleWithMerchantDetails (merchantDetails, goLiveStage) {
+function buildServiceRoleWithMerchantDetails(merchantDetails, goLiveStage) {
   return {
     service: {
       external_id: variables.serviceExternalId,
       gateway_account_ids: [variables.gatewayAccountId],
       merchant_details: merchantDetails,
-      current_go_live_stage: goLiveStage
-    }
+      current_go_live_stage: goLiveStage,
+    },
   }
 }
 
-function getUserAndGatewayAccountStubs (serviceRole) {
+function getUserAndGatewayAccountStubs(serviceRole) {
   return [
     userStubs.getUserSuccessWithServiceRole({ userExternalId: variables.userExternalId, serviceRole }),
     gatewayAccountStubs.getGatewayAccountSuccess({
       gatewayAccountId: variables.gatewayAccountId,
-      gatewayAccountExternalId: variables.gatewayAccountExternalId
-    })
+      gatewayAccountExternalId: variables.gatewayAccountExternalId,
+    }),
   ]
 }
 
-function getUserAndGatewayAccountsStubs (serviceRole) {
+function getUserAndGatewayAccountsStubs(serviceRole) {
   return [
     userStubs.getUserSuccessWithServiceRole({ userExternalId: variables.userExternalId, serviceRole }),
     gatewayAccountStubs.getGatewayAccountSuccess({
       gatewayAccountId: variables.gatewayAccountId,
-      gatewayAccountExternalId: variables.gatewayAccountExternalId
-    })
+      gatewayAccountExternalId: variables.gatewayAccountExternalId,
+    }),
   ]
 }
 
-function getUserAndGatewayAccountByExternalIdStubs (serviceRole, paymentProvider, accountType) {
+function getUserAndGatewayAccountByExternalIdStubs(serviceRole, paymentProvider, accountType) {
   return [
     userStubs.getUserSuccessWithServiceRole({ userExternalId: variables.userExternalId, serviceRole }),
     gatewayAccountStubs.getAccountByServiceIdAndAccountType(variables.serviceExternalId, accountType, {
       gateway_account_id: variables.gatewayAccountId,
       external_id: variables.gatewayAccountExternalId,
-      payment_provider: paymentProvider || 'sandbox'
+      payment_provider: paymentProvider || 'sandbox',
     }),
     gatewayAccountStubs.getGatewayAccountByExternalIdSuccess({
       gatewayAccountId: variables.gatewayAccountId,
       gatewayAccountExternalId: variables.gatewayAccountExternalId,
-      paymentProvider: paymentProvider || 'sandbox'
+      paymentProvider: paymentProvider || 'sandbox',
     }),
-    gatewayAccountStubs.getGatewayAccountsSuccess(
-      {
-        gatewayAccountId: variables.gatewayAccountId,
-        paymentProvider: paymentProvider || 'sandbox',
-        type: accountType || 'test'
-      })
+    gatewayAccountStubs.getGatewayAccountsSuccess({
+      gatewayAccountId: variables.gatewayAccountId,
+      paymentProvider: paymentProvider || 'sandbox',
+      type: accountType || 'test',
+    }),
   ]
 }
 
-function patchUpdateGoLiveStageSuccessStub (currentGoLiveStage) {
+function patchUpdateGoLiveStageSuccessStub(currentGoLiveStage) {
   return serviceStubs.patchUpdateServiceGoLiveStageSuccess({
     serviceExternalId: variables.serviceExternalId,
     gatewayAccountId: variables.gatewayAccountId,
-    currentGoLiveStage
+    currentGoLiveStage,
   })
 }
 
-function patchUpdateGoLiveStageErrorStub (currentGoLiveStage) {
+function patchUpdateGoLiveStageErrorStub(currentGoLiveStage) {
   return serviceStubs.patchGoLiveStageFailure({
     serviceExternalId: variables.serviceExternalId,
     gatewayAccountId: variables.gatewayAccountId,
-    currentGoLiveStage
+    currentGoLiveStage,
   })
 }
 
-function patchUpdateServiceSuccessCatchAllStub (currentGoLiveStage) {
+function patchUpdateServiceSuccessCatchAllStub(currentGoLiveStage) {
   return serviceStubs.patchUpdateServiceSuccessCatchAll({
     serviceExternalId: variables.serviceExternalId,
-    currentGoLiveStage
+    currentGoLiveStage,
   })
 }
 
-function setupGetUserAndGatewayAccountStubs (serviceRole) {
+function setupGetUserAndGatewayAccountStubs(serviceRole) {
   cy.task('setupStubs', getUserAndGatewayAccountStubs(serviceRole))
 }
 
-function setupGetUserAndGatewayAccountsStubs (serviceRole) {
+function setupGetUserAndGatewayAccountsStubs(serviceRole) {
   cy.task('setupStubs', getUserAndGatewayAccountsStubs(serviceRole))
 }
 
-function setupGetUserAndGatewayAccountByExternalIdStubs (serviceRole) {
+function setupGetUserAndGatewayAccountByExternalIdStubs(serviceRole) {
   cy.task('setupStubs', getUserAndGatewayAccountByExternalIdStubs(serviceRole))
 }
 
@@ -121,5 +120,5 @@ module.exports = {
   patchUpdateServiceSuccessCatchAllStub,
   setupGetUserAndGatewayAccountStubs,
   setupGetUserAndGatewayAccountsStubs,
-  setupGetUserAndGatewayAccountByExternalIdStubs
+  setupGetUserAndGatewayAccountByExternalIdStubs,
 }

--- a/test/cypress/utils/request-to-go-live-utils.js
+++ b/test/cypress/utils/request-to-go-live-utils.js
@@ -11,13 +11,17 @@ const variables = {
   serviceExternalId: 'afe452323dd04d1898672bfaba25e3a6',
 }
 
-function buildServiceRoleForGoLiveStage(goLiveStage, features) {
+function buildServiceRoleForGoLiveStage(goLiveStage, isAdyenEnabled) {
   return {
     service: {
       external_id: variables.serviceExternalId,
       current_go_live_stage: goLiveStage,
       gateway_account_ids: [`${variables.gatewayAccountId}`],
-      features: [features],
+      service_features: {
+        govuk_psp_is_adyen: {
+          enabled: isAdyenEnabled,
+        },
+      },
     },
   }
 }

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -119,7 +119,8 @@ module.exports = {
       current_psp_test_account_stage: 'NOT_STARTED',
       agent_initiated_moto_enabled: false,
       takes_payments_over_phone: false,
-      created_date: '2024-08-30'
+      created_date: '2024-08-30',
+      features: []
     })
 
     const service = {
@@ -135,7 +136,8 @@ module.exports = {
       current_psp_test_account_stage: opts.current_psp_test_account_stage,
       agent_initiated_moto_enabled: opts.agent_initiated_moto_enabled,
       takes_payments_over_phone: opts.takes_payments_over_phone,
-      created_date: opts.created_date
+      created_date: opts.created_date,
+      features: opts.features
     }
 
     if (opts.merchant_details) {

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -120,7 +120,11 @@ module.exports = {
       agent_initiated_moto_enabled: false,
       takes_payments_over_phone: false,
       created_date: '2024-08-30',
-      features: [],
+      serviceFeatures: {
+        govuk_psp_is_adyen: {
+          enabled: true,
+        },
+      },
     })
 
     const service = {
@@ -137,7 +141,11 @@ module.exports = {
       agent_initiated_moto_enabled: opts.agent_initiated_moto_enabled,
       takes_payments_over_phone: opts.takes_payments_over_phone,
       created_date: opts.created_date,
-      features: opts.features,
+      service_features: {
+        govuk_psp_is_adyen: {
+          enabled: Boolean(opts.service_features?.govuk_psp_is_adyen?.enabled || opts.govuk_psp_is_adyen_enabled),
+        },
+      },
     }
 
     if (opts.merchant_details) {

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -4,11 +4,11 @@ const lodash = require('lodash')
 
 const buildServiceNameWithDefaults = (opts = {}) => {
   lodash.defaults(opts, {
-    en: 'System Generated'
+    en: 'System Generated',
   })
 
   const serviceName = {
-    en: opts.en
+    en: opts.en,
   }
   if (opts.cy !== undefined) {
     serviceName.cy = opts.cy
@@ -29,20 +29,20 @@ module.exports = {
   validUpdateServiceNameRequest: (opts = {}) => {
     lodash.defaults(opts, {
       en: 'new-en-name',
-      cy: 'new-cy-name'
+      cy: 'new-cy-name',
     })
 
     return [
       {
         op: 'replace',
         path: 'service_name/en',
-        value: opts.en
+        value: opts.en,
       },
       {
         op: 'replace',
         path: 'service_name/cy',
-        value: opts.cy
-      }
+        value: opts.cy,
+      },
     ]
   },
 
@@ -50,7 +50,7 @@ module.exports = {
     return {
       op: 'add',
       path: 'gateway_account_ids',
-      value: gatewayAccountIds.map(id => `${id}`)
+      value: gatewayAccountIds.map((id) => `${id}`),
     }
   },
 
@@ -58,7 +58,7 @@ module.exports = {
     return {
       op: 'replace',
       path: 'collect_billing_address',
-      value: opts.enabled || false
+      value: opts.enabled || false,
     }
   },
 
@@ -66,7 +66,7 @@ module.exports = {
     return {
       op: 'replace',
       path: 'default_billing_address_country',
-      value: countryCode
+      value: countryCode,
     }
   },
 
@@ -74,7 +74,7 @@ module.exports = {
     return {
       op: 'replace',
       path: 'current_go_live_stage',
-      value
+      value,
     }
   },
 
@@ -82,16 +82,16 @@ module.exports = {
     return {
       op: 'replace',
       path: 'current_psp_test_account_stage',
-      value
+      value,
     }
   },
 
   validUpdateMerchantDetailsRequest: (merchantDetails) => {
-    return Object.keys(merchantDetails).map(key => {
+    return Object.keys(merchantDetails).map((key) => {
       return {
         op: 'replace',
         path: `merchant_details/${key}`,
-        value: merchantDetails[key]
+        value: merchantDetails[key],
       }
     })
   },
@@ -100,7 +100,7 @@ module.exports = {
     return {
       op: 'replace',
       path: opts.path,
-      value: opts.value
+      value: opts.value,
     }
   },
 
@@ -111,7 +111,7 @@ module.exports = {
       name: 'System Generated',
       gateway_account_ids: ['666'],
       service_name: {
-        en: 'System Generated'
+        en: 'System Generated',
       },
       redirect_to_service_immediately_on_terminal_state: false,
       collect_billing_address: false,
@@ -120,7 +120,7 @@ module.exports = {
       agent_initiated_moto_enabled: false,
       takes_payments_over_phone: false,
       created_date: '2024-08-30',
-      features: []
+      features: [],
     })
 
     const service = {
@@ -137,7 +137,7 @@ module.exports = {
       agent_initiated_moto_enabled: opts.agent_initiated_moto_enabled,
       takes_payments_over_phone: opts.takes_payments_over_phone,
       created_date: opts.created_date,
-      features: opts.features
+      features: opts.features,
     }
 
     if (opts.merchant_details) {
@@ -150,16 +150,15 @@ module.exports = {
         'address_country',
         'email',
         'telephone_number',
-        'url'
+        'url',
       ])
     }
 
     if (opts.default_billing_address_country !== null) {
-      service.default_billing_address_country = opts.default_billing_address_country === undefined
-        ? 'GB'
-        : opts.default_billing_address_country
+      service.default_billing_address_country =
+        opts.default_billing_address_country === undefined ? 'GB' : opts.default_billing_address_country
     }
 
     return service
-  }
+  },
 }

--- a/test/fixtures/service/service.fixture.ts
+++ b/test/fixtures/service/service.fixture.ts
@@ -1,4 +1,4 @@
-import { ServiceData } from '@models/service/dto/Service.dto'
+import { ServiceData, ServiceFeature, ServiceFeatures } from '@models/service/dto/Service.dto'
 import Service from '@models/service/Service.class'
 import { MerchantDetailsFixture } from '@test/fixtures/service/merchant-details.fixture'
 
@@ -17,6 +17,7 @@ export class ServiceFixture {
   readonly agentInitiatedMotoEnabled: boolean
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
+  readonly serviceFeatures: ServiceFeatures
 
   constructor(...overrides: Partial<ServiceFixture>[]) {
     this.id = 1
@@ -33,6 +34,11 @@ export class ServiceFixture {
     this.currentPspTestAccountStage = ''
     this.agentInitiatedMotoEnabled = false
     this.takesPaymentsOverPhone = false
+    this.serviceFeatures = {
+        govuk_psp_is_adyen: {
+          enabled: false,
+        },
+      }
 
     overrides?.forEach((overrideValues) => {
       Object.assign(this, overrideValues)
@@ -55,6 +61,7 @@ export class ServiceFixture {
       agent_initiated_moto_enabled: this.agentInitiatedMotoEnabled,
       default_billing_address_country: this.defaultBillingAddressCountry,
       takes_payments_over_phone: this.takesPaymentsOverPhone,
+      service_features: this.serviceFeatures
     }
   }
 

--- a/test/fixtures/service/service.fixture.ts
+++ b/test/fixtures/service/service.fixture.ts
@@ -35,10 +35,10 @@ export class ServiceFixture {
     this.agentInitiatedMotoEnabled = false
     this.takesPaymentsOverPhone = false
     this.serviceFeatures = {
-        govuk_psp_is_adyen: {
-          enabled: false,
-        },
-      }
+      govuk_psp_is_adyen: {
+        enabled: false,
+      },
+    }
 
     overrides?.forEach((overrideValues) => {
       Object.assign(this, overrideValues)
@@ -61,7 +61,7 @@ export class ServiceFixture {
       agent_initiated_moto_enabled: this.agentInitiatedMotoEnabled,
       default_billing_address_country: this.defaultBillingAddressCountry,
       takes_payments_over_phone: this.takesPaymentsOverPhone,
-      service_features: this.serviceFeatures
+      service_features: this.serviceFeatures,
     }
   }
 

--- a/test/fixtures/service/service.fixture.ts
+++ b/test/fixtures/service/service.fixture.ts
@@ -1,4 +1,4 @@
-import { ServiceData, ServiceFeature, ServiceFeatures } from '@models/service/dto/Service.dto'
+import { ServiceData, ServiceFeatures } from '@models/service/dto/Service.dto'
 import Service from '@models/service/Service.class'
 import { MerchantDetailsFixture } from '@test/fixtures/service/merchant-details.fixture'
 

--- a/test/fixtures/user.fixtures.js
+++ b/test/fixtures/user.fixtures.js
@@ -10,246 +10,246 @@ const secondFactorMethod = require('@models/constants/second-factor-method')
 const defaultPermissions = [
   {
     name: 'users-service:read',
-    description: 'Viewusersinservice'
+    description: 'Viewusersinservice',
   },
   {
     name: 'users-service:create',
-    description: 'Createuserinthisservice'
+    description: 'Createuserinthisservice',
   },
   {
     name: 'tokens-active:read',
-    description: 'Viewactivekeys'
+    description: 'Viewactivekeys',
   },
   {
     name: 'tokens-revoked:read',
-    description: 'Viewrevokedkeys'
+    description: 'Viewrevokedkeys',
   },
   {
     name: 'tokens:create',
-    description: 'Generatekey'
+    description: 'Generatekey',
   },
   {
     name: 'tokens:update',
-    description: 'Generatekey'
+    description: 'Generatekey',
   },
   {
     name: 'tokens:delete',
-    description: 'Revokekey'
+    description: 'Revokekey',
   },
   {
     name: 'transactions:read',
-    description: 'Viewtransactionslist'
+    description: 'Viewtransactionslist',
   },
   {
     name: 'transactions-by-date:read',
-    description: 'Searchtransactionsbydate'
+    description: 'Searchtransactionsbydate',
   },
   {
     name: 'transactions-by-fields:read',
-    description: 'Searchtransactionsbypaymentfields'
+    description: 'Searchtransactionsbypaymentfields',
   },
   {
     name: 'transactions-download:read',
-    description: 'Downloadtransactions'
+    description: 'Downloadtransactions',
   },
   {
     name: 'transactions-details:read',
-    description: 'Viewtransactiondetails'
+    description: 'Viewtransactiondetails',
   },
   {
     name: 'transactions-events:read',
-    description: 'Viewtransactionevents'
+    description: 'Viewtransactionevents',
   },
   {
     name: 'refunds:create',
-    description: 'Issuerefund'
+    description: 'Issuerefund',
   },
   {
     name: 'transactions-amount:read',
-    description: 'Viewtransactionamounts'
+    description: 'Viewtransactionamounts',
   },
   {
     name: 'transactions-description:read',
-    description: 'Viewtransactiondescription'
+    description: 'Viewtransactiondescription',
   },
   {
     name: 'transactions-email:read',
-    description: 'Viewtransactionemail'
+    description: 'Viewtransactionemail',
   },
   {
     name: 'transactions-card-type:read',
-    description: 'Viewtransactioncardtype'
+    description: 'Viewtransactioncardtype',
   },
   {
     name: 'gateway-credentials:read',
-    description: 'Viewgatewayaccountcredentials'
+    description: 'Viewgatewayaccountcredentials',
   },
   {
     name: 'gateway-credentials:update',
-    description: 'Editgatewayaccountcredentials'
+    description: 'Editgatewayaccountcredentials',
   },
   {
     name: 'service-name:read',
-    description: 'Viewservicename'
+    description: 'Viewservicename',
   },
   {
     name: 'service-name:update',
-    description: 'Editservicename'
+    description: 'Editservicename',
   },
   {
     name: 'payment-types:read',
-    description: 'Viewpaymenttypes'
+    description: 'Viewpaymenttypes',
   },
   {
     name: 'payment-types:update',
-    description: 'Editpaymenttypes'
+    description: 'Editpaymenttypes',
   },
   {
     name: 'email-notification-template:read',
-    description: 'Viewemailnotificationstemplate'
+    description: 'Viewemailnotificationstemplate',
   },
   {
     name: 'email-notification-paragraph:update',
-    description: 'Editemailnotificationsparagraph'
+    description: 'Editemailnotificationsparagraph',
   },
   {
     name: 'email-notification-toggle:update',
-    description: 'Turnemailnotificationson/off'
+    description: 'Turnemailnotificationson/off',
   },
   {
     name: 'tokens:read',
-    description: 'View keys'
+    description: 'View keys',
   },
   {
     name: 'toggle-3ds:read',
-    description: 'View 3D Secure setting'
+    description: 'View 3D Secure setting',
   },
   {
     name: 'toggle-3ds:update',
-    description: 'Edit 3D Secure setting'
+    description: 'Edit 3D Secure setting',
   },
   {
     name: 'users-service:delete',
-    description: 'Remove user from a service'
+    description: 'Remove user from a service',
   },
   {
     name: 'merchant-details:read',
-    description: 'View Merchant Details setting'
+    description: 'View Merchant Details setting',
   },
   {
     name: 'merchant-details:update',
-    description: 'Edit Merchant Details setting'
+    description: 'Edit Merchant Details setting',
   },
   {
     name: 'toggle-billing-address:read',
-    description: 'View Billing Address setting'
+    description: 'View Billing Address setting',
   },
   {
     name: 'toggle-billing-address:update',
-    description: 'Edit Billing Address setting'
+    description: 'Edit Billing Address setting',
   },
   {
     name: 'go-live-stage:update',
-    description: 'Update Go Live stage'
+    description: 'Update Go Live stage',
   },
   {
     name: 'go-live-stage:read',
-    description: 'View Go Live stage'
+    description: 'View Go Live stage',
   },
   {
     name: 'stripe-account-details:update',
-    description: 'Update any Stripe account onboarding details'
+    description: 'Update any Stripe account onboarding details',
   },
   {
     name: 'stripe-bank-details:update',
-    description: 'Update Stripe bank details'
+    description: 'Update Stripe bank details',
   },
   {
     name: 'stripe-bank-details:read',
-    description: 'View Stripe bank details'
+    description: 'View Stripe bank details',
   },
   {
     name: 'stripe-responsible-person:update',
-    description: 'Update Stripe responsible person'
+    description: 'Update Stripe responsible person',
   },
   {
     name: 'stripe-responsible-person:read',
-    description: 'View Stripe responsible person'
+    description: 'View Stripe responsible person',
   },
   {
     name: 'stripe-director:update',
-    description: 'Update Stripe director'
+    description: 'Update Stripe director',
   },
   {
     name: 'stripe-director:read',
-    description: 'View Stripe director'
+    description: 'View Stripe director',
   },
   {
     name: 'stripe-vat-number-company-number:update',
-    description: 'Update Stripe VAT number company number'
+    description: 'Update Stripe VAT number company number',
   },
   {
     name: 'stripe-vat-number-company-number:read',
-    description: 'View Stripe VAT number company number'
+    description: 'View Stripe VAT number company number',
   },
   {
     name: 'stripe-government-entity-document:update',
-    description: 'Upload Government entity document'
+    description: 'Upload Government entity document',
   },
   {
     name: 'stripe-organisation-details:update',
-    description: 'Check organisation details with Government entity document'
+    description: 'Check organisation details with Government entity document',
   },
   {
     name: 'connected-gocardless-account:read',
-    description: 'View connected go cardless account'
+    description: 'View connected go cardless account',
   },
   {
     name: 'connected-gocardless-account:update',
-    description: 'Update connected go cardless account'
+    description: 'Update connected go cardless account',
   },
   {
     name: 'payouts:read',
-    description: 'View payouts'
+    description: 'View payouts',
   },
   {
     name: 'moto-mask-input:update',
-    description: 'Update moto mask for card number and security code'
+    description: 'Update moto mask for card number and security code',
   },
   {
     name: 'moto-mask-input:read',
-    description: 'View moto mask for card number and security code'
+    description: 'View moto mask for card number and security code',
   },
   {
     name: 'psp-test-account-stage:update',
-    description: 'Update PSP Test Account stage'
+    description: 'Update PSP Test Account stage',
   },
   {
     name: 'webhooks:read',
-    description: 'View webhooks'
+    description: 'View webhooks',
   },
   {
     name: 'webhooks:update',
-    description: 'Update webhooks'
+    description: 'Update webhooks',
   },
   {
     name: 'agreements:read',
-    description: 'View agreements'
+    description: 'View agreements',
   },
   {
     name: 'agreements:update',
-    description: 'Update agreements'
+    description: 'Update agreements',
   },
   {
     name: 'agent-initiated-moto:create',
-    description: 'Create agent initiated moto payments'
-  }
+    description: 'Create agent initiated moto payments',
+  },
 ]
 
 const buildServiceRole = (opts = {}) => {
   return {
     service: serviceFixtures.validServiceResponse(opts.service),
-    role: buildRoleWithDefaults(opts.role)
+    role: buildRoleWithDefaults(opts.role),
   }
 }
 
@@ -257,11 +257,11 @@ const buildRoleWithDefaults = (opts = {}) => {
   return {
     name: opts.name || 'admin',
     description: opts.role_description || 'Administrator',
-    permissions: opts.permissions || defaultPermissions
+    permissions: opts.permissions || defaultPermissions,
   }
 }
 
-function buildUserWithDefaults (opts) {
+function buildUserWithDefaults(opts) {
   lodash.defaults(opts, {
     external_id: '7d19aff33f8948deb97ed16b2912dcd3',
     email: 'some-user@example.com',
@@ -274,11 +274,13 @@ function buildUserWithDefaults (opts) {
     login_counter: 0,
     session_version: 0,
     features: null,
-    _links: [{
-      rel: 'self',
-      method: 'GET',
-      href: 'http://127.0.0.1:8080/v1/api/users/09283568e105442da3928d1fa99fb0eb'
-    }]
+    _links: [
+      {
+        rel: 'self',
+        method: 'GET',
+        href: 'http://127.0.0.1:8080/v1/api/users/09283568e105442da3928d1fa99fb0eb',
+      },
+    ],
   })
 
   const serviceRoles = opts.service_roles ? lodash.flatMap(opts.service_roles, buildServiceRole) : [buildServiceRole()]
@@ -294,8 +296,7 @@ function buildUserWithDefaults (opts) {
     disabled: opts.disabled,
     login_counter: opts.login_counter,
     session_version: opts.session_version,
-    features: opts.features,
-    _links: opts._links
+    _links: opts._links,
   }
 }
 
@@ -307,7 +308,7 @@ module.exports = {
     const newExternalId = opts.external_id || '121391373c1844dd99cb3416b70785c8'
     const defaultServiceId = opts.default_service_id || '193'
     const gatewayAccountIds = opts.gateway_account_ids || ['540']
-    const collectBillingAddress = (opts.collect_billing_address && opts.collect_billing_address === true)
+    const collectBillingAddress = opts.collect_billing_address && opts.collect_billing_address === true
     const currentGoLiveStage = opts.current_go_live_stage || goLiveStage.NOT_STARTED
     const currentPspTestAccountStage = opts.current_psp_test_account_stage || stripeTestAccountStage.NOT_STARTED
     const agentInitiatedMotoEnabled = opts.agent_initiated_moto_enabled || false
@@ -315,29 +316,31 @@ module.exports = {
     const userOpts = {
       external_id: opts.external_id || newExternalId,
       email: opts.email || 'user@example.com',
-      service_roles: opts.service_roles || [{
-        service: {
-          name: 'System Generated',
-          external_id: defaultServiceId,
-          gateway_account_ids: gatewayAccountIds,
-          collect_billing_address: collectBillingAddress,
-          current_go_live_stage: currentGoLiveStage,
-          current_psp_test_account_stage: currentPspTestAccountStage,
-          agent_initiated_moto_enabled: agentInitiatedMotoEnabled
+      service_roles: opts.service_roles || [
+        {
+          service: {
+            name: 'System Generated',
+            external_id: defaultServiceId,
+            gateway_account_ids: gatewayAccountIds,
+            collect_billing_address: collectBillingAddress,
+            current_go_live_stage: currentGoLiveStage,
+            current_psp_test_account_stage: currentPspTestAccountStage,
+            agent_initiated_moto_enabled: agentInitiatedMotoEnabled,
+          },
+          role: opts.role || {
+            name: 'admin',
+            description: 'Administrator',
+            permissions: opts.permissions || [{ name: 'perm-1' }],
+          },
         },
-        role: opts.role || {
-          name: 'admin',
-          description: 'Administrator',
-          permissions: opts.permissions || [{ name: 'perm-1' }]
-        }
-      }],
+      ],
       telephone_number: opts.telephone_number || '940583',
       otp_key: opts.otp_key || '2994',
       disabled: opts.disabled || false,
       login_counter: opts.login_counter || 0,
       session_version: opts.session_version || 0,
       second_factor: opts.second_factor || secondFactorMethod.SMS,
-      provisional_otp_key: opts.provisional_otp_key || '60400'
+      provisional_otp_key: opts.provisional_otp_key || '60400',
     }
 
     // pass this through the known valid structure builder to ensure structure is correct
@@ -347,19 +350,19 @@ module.exports = {
   validAuthenticateRequest: (options) => {
     return {
       email: options.email || 'username@example.com',
-      password: options.password || 'password'
+      password: options.password || 'password',
     }
   },
 
   unauthorizedUserResponse: () => {
     return {
-      errors: ['invalid email and/or password']
+      errors: ['invalid email and/or password'],
     }
   },
 
   badAuthenticateResponse: () => {
     return {
-      errors: ['Field [email] is required', 'Field [password] is required']
+      errors: ['Field [email] is required', 'Field [password] is required'],
     }
   },
 
@@ -367,40 +370,40 @@ module.exports = {
     return {
       op: 'append',
       path: 'sessionVersion',
-      value: 1
+      value: 1,
     }
   },
 
   validAuthenticateSecondFactorRequest: (code) => {
     return {
-      code: code || '123456'
+      code: code || '123456',
     }
   },
 
   validUpdatePasswordRequest: (token, newPassword) => {
     return {
       forgotten_password_code: token || '5ylaem',
-      new_password: newPassword || 'G0VUkPay2017Rocks'
+      new_password: newPassword || 'G0VUkPay2017Rocks',
     }
   },
 
   validUpdateServiceRoleRequest: (role) => {
     return {
-      role_name: role || 'admin'
+      role_name: role || 'admin',
     }
   },
 
   validAssignServiceRoleRequest: (opts = {}) => {
     return {
       service_external_id: opts.service_external_id || '9en17v',
-      role_name: opts.role_name || 'admin'
+      role_name: opts.role_name || 'admin',
     }
   },
 
   validPasswordAuthenticateRequest: (opts = {}) => {
     return {
       email: opts.email || 'valid-email@example.com',
-      password: opts.password || 'validpassword'
+      password: opts.password || 'validpassword',
     }
   },
 
@@ -414,13 +417,13 @@ module.exports = {
 
   invalidPasswordAuthenticateResponse: () => {
     return {
-      errors: ['invalid email and/or password']
+      errors: ['invalid email and/or password'],
     }
   },
 
   validForgottenPasswordCreateRequest: (username) => {
     return {
-      username: username || 'username@email.com'
+      username: username || 'username@email.com',
     }
   },
 
@@ -431,17 +434,19 @@ module.exports = {
       user_external_id: request.userExternalId || 'userExternalId',
       code: request.code || code,
       date: '2010-12-31T22:59:59.132Z',
-      _links: [{
-        href: `http://127.0.0.1:8080/v1/api/forgotten-passwords/${code}`,
-        rel: 'self',
-        method: 'GET'
-      }]
+      _links: [
+        {
+          href: `http://127.0.0.1:8080/v1/api/forgotten-passwords/${code}`,
+          rel: 'self',
+          method: 'GET',
+        },
+      ],
     }
   },
 
   badForgottenPasswordResponse: () => {
     return {
-      errors: ['Field [username] is required']
+      errors: ['Field [username] is required'],
     }
   },
 
@@ -449,7 +454,7 @@ module.exports = {
     return {
       op: 'replace',
       path: 'telephone_number',
-      value: telephoneNumber
+      value: telephoneNumber,
     }
   },
 
@@ -457,7 +462,7 @@ module.exports = {
     return {
       op: 'replace',
       path: 'features',
-      value: featuresString
+      value: featuresString,
     }
-  }
+  },
 }


### PR DESCRIPTION
## What

[PP-15686
](https://payments-platform.atlassian.net/browse/PP-15686)

This PR updates logic for determining which PSP can be selected as GOV.UK Pay’s Provider in the request to go live journey to be conditional on either the environment wide feature, or govuk_psp_is_adyen feature being set to enabled. This PR follows on the work done to add this feature to admin users [here](https://github.com/alphagov/pay-adminusers/pull/3342). 

- Added serviceFeatures to Service class, matching structure from admin-users 
- Updated controllers to either check for existing environment wide feature OR govuk_psp_is_adyen being set to enabled to configure whether adyen can be selected as PSP. 
- Updated njk files to use above logic
- Removed `enable_go_live_requests_for_adyen` from experimental features list in env so we just deal with service feature in testing
- Test utils and features updated
- Tests updated to now go through options as follows: 
             - Service feature is disabled in choose-how-to-process-payments - stripe displays, adyen doesn't
             - Service feature is enabled in choose-how-to-process-payments - adyen displays
             - Service feature is disabled and CHOSEN_PSP_STRIPE in agreements - stripe displays, adyen doesn't
             - Service feature is enabled and CHOSEN_PSP_ADYEN in agreements - adyen displays

