### PR TITLE
PP-15746 Add unit tests for switch-to-adyen controller

### DIFF
--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
@@ -1,0 +1,78 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import sinon from 'sinon'
+import { AdyenTasks } from '@models/task-workflows/AdyenTasks.class'
+import { AdyenTaskIdentifier } from '@models/task-workflows/task-identifiers/adyen-task-identifiers'
+import TaskStatus from '@models/constants/task-status'
+
+const SERVICE_EXTERNAL_ID = 'service123abc'
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+})
+
+const mockResponse = sinon.stub()
+
+const { req, res, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller'
+)
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withAccount(
+    GatewayAccountFixture.forSwitchingPsp(PaymentProvider.STRIPE, PaymentProvider.ADYEN, {
+      type: 'live',
+    }).toGatewayAccount()
+  )
+  .withUser(UserFixture.asServiceAdmin([serviceFixture]).toUser())
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('Switch to Adyen controller tests', () => {
+  it('should call the response function with req, res, and the template path', async () => {
+    await call('get')
+
+    mockResponse.should.have.been.calledOnce
+    mockResponse.should.have.been.calledWith(
+      req,
+      res,
+      'simplified-account/settings/switch-psp/switch-to-adyen/index.njk'
+    )
+  })
+
+  it('should call the response method with the task list', async () => {
+    await call('get')
+
+    mockResponse.should.have.been.calledOnce
+    const context = mockResponse.firstCall.lastArg as {
+      currentPsp: PaymentProvider
+      adyenTasks: AdyenTasks
+    }
+
+    context.currentPsp.should.eq(PaymentProvider.STRIPE)
+    context.adyenTasks.tasks.should.have.length(6)
+    context.adyenTasks.confirmOrganisationTasks.should.have.length(1)
+    context.adyenTasks.acceptLegalTermsTasks.should.have.length(1)
+    context.adyenTasks.completeOrganisationDetailsTasks.should.have.length(4)
+
+    context.adyenTasks.confirmOrganisationTasks[0].id.should.eq(AdyenTaskIdentifier.ORG_DETAILS)
+    context.adyenTasks.confirmOrganisationTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
+
+    context.adyenTasks.acceptLegalTermsTasks[0].id.should.eq(AdyenTaskIdentifier.LEGAL_TERMS)
+    context.adyenTasks.acceptLegalTermsTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
+
+    context.adyenTasks.completeOrganisationDetailsTasks[0].id.should.eq(AdyenTaskIdentifier.BANK_DETAILS)
+    context.adyenTasks.completeOrganisationDetailsTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
+
+    context.adyenTasks.completeOrganisationDetailsTasks[1].id.should.eq(AdyenTaskIdentifier.RESPONSIBLE_PERSON)
+    context.adyenTasks.completeOrganisationDetailsTasks[1].status.should.eq(TaskStatus.NOT_STARTED)
+
+    context.adyenTasks.completeOrganisationDetailsTasks[2].id.should.eq(AdyenTaskIdentifier.SERVICE_DIRECTOR)
+    context.adyenTasks.completeOrganisationDetailsTasks[2].status.should.eq(TaskStatus.NOT_STARTED)
+
+    context.adyenTasks.completeOrganisationDetailsTasks[3].id.should.eq(AdyenTaskIdentifier.REASON_FOR_TAKING_PAYMENTS)
+    context.adyenTasks.completeOrganisationDetailsTasks[3].status.should.eq(TaskStatus.NOT_STARTED)
+  })
+})

--- a/src/models/constants/payment-provider.ts
+++ b/src/models/constants/payment-provider.ts
@@ -1,0 +1,4 @@
+import PaymentProviders from '@models/constants/payment-providers'
+
+export type PaymentProvider = (typeof PaymentProviders)[keyof typeof PaymentProviders]
+export const PaymentProvider = PaymentProviders

--- a/src/models/constants/payment-providers.ts
+++ b/src/models/constants/payment-providers.ts
@@ -3,6 +3,6 @@ const PaymentProviders = {
   WORLDPAY: 'worldpay',
   SANDBOX: 'sandbox',
   ADYEN: 'adyen',
-}
+} as const
 
 export = PaymentProviders

--- a/src/models/gateway-account-credential/GatewayAccountCredential.class.ts
+++ b/src/models/gateway-account-credential/GatewayAccountCredential.class.ts
@@ -1,9 +1,10 @@
 import Credential from '@models/gateway-account-credential/Credential.class'
 import { GatewayAccountCredentialData } from '@models/gateway-account-credential/dto/GatewayAccountCredential.dto'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 class GatewayAccountCredential {
   public externalId!: string
-  public paymentProvider!: string
+  public paymentProvider!: PaymentProvider
   public credentials!: Credential
   public state!: string
   public createdDate?: string
@@ -16,7 +17,7 @@ class GatewayAccountCredential {
     return this
   }
 
-  withPaymentProvider(paymentProvider: string) {
+  withPaymentProvider(paymentProvider: PaymentProvider) {
     this.paymentProvider = paymentProvider
     return this
   }

--- a/src/models/gateway-account-credential/dto/GatewayAccountCredential.dto.ts
+++ b/src/models/gateway-account-credential/dto/GatewayAccountCredential.dto.ts
@@ -1,8 +1,9 @@
 import { CredentialData } from '@models/gateway-account-credential/dto/Credential.dto'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 export interface GatewayAccountCredentialData {
   external_id: string
-  payment_provider: string
+  payment_provider: PaymentProvider
   credentials: CredentialData
   state: string
   created_date: string

--- a/src/models/gateway-account/GatewayAccount.class.ts
+++ b/src/models/gateway-account/GatewayAccount.class.ts
@@ -3,10 +3,11 @@ import { InvalidConfigurationError, NotFoundError } from '@root/errors'
 import CredentialState from '@models/constants/credential-state'
 import { GatewayAccountData } from '@models/gateway-account/dto/GatewayAccount.dto'
 import GatewayAccountCredential from '@models/gateway-account-credential/GatewayAccountCredential.class'
-import PaymentProvider from '@models/constants/payment-providers'
+import { PaymentProvider } from '@models/constants/payment-provider'
 import { EmailNotifications } from '@models/gateway-account/EmailNotifications.class'
 
 const pendingCredentialStates = [CredentialState.CREATED, CredentialState.ENTERED, CredentialState.VERIFIED]
+const PAYMENT_PROVIDERS_WHICH_SUPPORT_3DS: string[] = [PaymentProvider.WORLDPAY, PaymentProvider.STRIPE]
 
 class GatewayAccount {
   readonly id: number
@@ -25,7 +26,7 @@ class GatewayAccount {
   readonly motoMaskCardNumber: boolean
   readonly motoMaskCardSecurityCode: boolean
   readonly name: string
-  readonly paymentProvider: string
+  readonly paymentProvider: PaymentProvider
   readonly providerSwitchEnabled: boolean
   readonly recurringEnabled: boolean
   readonly requires3ds: boolean
@@ -61,7 +62,7 @@ class GatewayAccount {
     this.providerSwitchEnabled = gatewayAccountData.provider_switch_enabled
     this.recurringEnabled = gatewayAccountData.recurring_enabled
     this.requires3ds = gatewayAccountData.requires3ds
-    this.supports3ds = [PaymentProvider.WORLDPAY, PaymentProvider.STRIPE].includes(gatewayAccountData.payment_provider)
+    this.supports3ds = PAYMENT_PROVIDERS_WHICH_SUPPORT_3DS.includes(gatewayAccountData.payment_provider)
     this.worldpay3dsFlex = gatewayAccountData.worldpay_3ds_flex
       ? Worldpay3dsFlexCredential.fromJson(gatewayAccountData.worldpay_3ds_flex)
       : undefined

--- a/src/models/gateway-account/dto/GatewayAccount.dto.ts
+++ b/src/models/gateway-account/dto/GatewayAccount.dto.ts
@@ -1,6 +1,7 @@
 import { EmailNotificationsData } from '@models/gateway-account/dto/EmailNotifications.dto'
 import { GatewayAccountCredentialData } from '@models/gateway-account-credential/dto/GatewayAccountCredential.dto'
 import { Worldpay3dsFlexCredentialData } from '@models/gateway-account-credential/dto/Worldpay3dsFlexCredential.dto'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 export interface GatewayAccountData {
   gateway_account_id: number
@@ -12,7 +13,7 @@ export interface GatewayAccountData {
   allow_moto: boolean
   analytics_id?: string
   description?: string
-  payment_provider: string
+  payment_provider: PaymentProvider
   gateway_account_credentials?: GatewayAccountCredentialData[]
   email_collection_mode: string
   email_notifications: EmailNotificationsData

--- a/src/models/service-view/ServiceView.class.ts
+++ b/src/models/service-view/ServiceView.class.ts
@@ -106,8 +106,12 @@ export class ServiceView {
   }
 }
 
-const PaymentProvidersThatCanGoLive = [PaymentProviders.SANDBOX, PaymentProviders.STRIPE, PaymentProviders.ADYEN]
-const ValidLivePaymentProviders = [PaymentProviders.WORLDPAY, PaymentProviders.STRIPE]
+const PaymentProvidersThatCanGoLive: string[] = [
+  PaymentProviders.SANDBOX,
+  PaymentProviders.STRIPE,
+  PaymentProviders.ADYEN,
+]
+const ValidLivePaymentProviders: string[] = [PaymentProviders.WORLDPAY, PaymentProviders.STRIPE]
 
 const GoLiveInProgressStages = [
   GoLiveStage.CHOSEN_PSP_GOV_BANKING_WORLDPAY,

--- a/src/utils/simplified-account/home/my-services/service-presentation-utils.ts
+++ b/src/utils/simplified-account/home/my-services/service-presentation-utils.ts
@@ -10,7 +10,7 @@ import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/fo
 import Service from '@models/service/Service.class'
 
 const logger = createLogger(__filename)
-const SUPPORTED_ACCOUNT_PROVIDERS = [
+const SUPPORTED_ACCOUNT_PROVIDERS: string[] = [
   PaymentProviders.STRIPE,
   PaymentProviders.SANDBOX,
   PaymentProviders.WORLDPAY,

--- a/src/utils/simplified-account/services/dashboard/actions-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/actions-utils.ts
@@ -2,7 +2,6 @@ import Service from '@models/service/Service.class'
 import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
 import User from '@models/user/User.class'
 import GoLiveStage from '@models/constants/go-live-stage'
-import PaymentProviders, { STRIPE, WORLDPAY } from '@models/constants/payment-providers'
 import PspTestAccountStage from '@models/constants/psp-test-account-stage'
 import { getProducts } from '@services/products.service'
 import createLogger from '@utils/logger'
@@ -13,6 +12,7 @@ import { getConnectorStripeAccountSetup, getStripeAccountCapabilities } from '@s
 import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 import { ProductType } from '@models/products/product-type'
 import { Features } from '@root/config/features'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 const logger = createLogger(__filename)
 
@@ -44,13 +44,19 @@ const goLiveRequestedStages = [
 
 const goLiveLinkNotDisplayedStages = [GoLiveStage.LIVE, GoLiveStage.DENIED]
 
+const PAYMENT_PROVIDERS_THAT_CAN_GO_LIVE: PaymentProvider[] = [
+  PaymentProvider.STRIPE,
+  PaymentProvider.WORLDPAY,
+  PaymentProvider.ADYEN,
+]
+
 const displayRequestTestStripeAccountLink = (service: Service, account: GatewayAccount, user: User) => {
   // Since 29/08/2024, services that identified as local govt were automatically allocated Stripe test accounts
   // Services created after that date don't need a link to create a Stripe test account
   // this change was deployed in PR #4256 at approx. 10:08 UTC so this time is used as the cutoff
   const serviceCreatedBeforeOrgTypeCaptured = new Date(service.createdDate) <= new Date('2024-08-29T10:08:00Z')
   return (
-    account.paymentProvider === PaymentProviders.SANDBOX &&
+    account.paymentProvider === PaymentProvider.SANDBOX &&
     service.currentGoLiveStage !== GoLiveStage.LIVE &&
     serviceCreatedBeforeOrgTypeCaptured &&
     service.currentPspTestAccountStage !== PspTestAccountStage.CREATED &&
@@ -68,8 +74,8 @@ const displayGoLiveLink = (service: Service, account: GatewayAccount, user: User
 
 const displayDemoAndTestPaymentLinks = (account: GatewayAccount) => {
   return (
-    account.paymentProvider === PaymentProviders.SANDBOX ||
-    (account.paymentProvider === PaymentProviders.STRIPE && account.type === GatewayAccountType.TEST)
+    account.paymentProvider === PaymentProvider.SANDBOX ||
+    (account.paymentProvider === PaymentProvider.STRIPE && account.type === GatewayAccountType.TEST)
   )
 }
 
@@ -102,7 +108,7 @@ const getTelephonePaymentLink = async (user: User, service: Service, gatewayAcco
 function isALiveStripeServiceAndAdminUser(service: Service, account: GatewayAccount, user: User) {
   return (
     account.type === GatewayAccountType.LIVE &&
-    account.paymentProvider === PaymentProviders.STRIPE &&
+    account.paymentProvider === PaymentProvider.STRIPE &&
     user.hasPermission(service.externalId, 'stripe-account-details:update')
   )
 }
@@ -165,14 +171,14 @@ const getConfigurePSPAccountLink = (service: Service, account: GatewayAccount) =
   const credential = account.getCurrentCredential()
   const paymentProvider = credential?.paymentProvider
 
-  if (!paymentProvider || ![WORLDPAY, STRIPE, PaymentProviders.ADYEN].includes(paymentProvider)) {
+  if (!paymentProvider || !PAYMENT_PROVIDERS_THAT_CAN_GO_LIVE.includes(paymentProvider)) {
     return undefined
   }
 
-  const simplifiedPaths = {
-    [WORLDPAY]: paths.simplifiedAccount.settings.worldpayDetails.index,
-    [STRIPE]: paths.simplifiedAccount.settings.stripeDetails.index,
-    [PaymentProviders.ADYEN]: paths.simplifiedAccount.settings.stripeDetails.index,
+  const simplifiedPaths: Record<string, string> = {
+    [PaymentProvider.WORLDPAY]: paths.simplifiedAccount.settings.worldpayDetails.index,
+    [PaymentProvider.STRIPE]: paths.simplifiedAccount.settings.stripeDetails.index,
+    [PaymentProvider.ADYEN]: paths.simplifiedAccount.settings.stripeDetails.index, // todo update this to Adyen when adyen-details routes are added
   }
 
   return formatServiceAndAccountPathsFor(simplifiedPaths[paymentProvider], service.externalId, account.type)
@@ -190,7 +196,7 @@ const getAccountStatus = async (account: GatewayAccount, service: Service) => {
     ...(account.providerSwitchEnabled && {
       targetPaymentProvider: account.getSwitchingCredential().paymentProvider,
     }),
-    ...(currentCredential?.paymentProvider === PaymentProviders.STRIPE &&
+    ...(currentCredential?.paymentProvider === PaymentProvider.STRIPE &&
       (await getStripeAccountStatus(account, service))),
   }
 }
@@ -214,7 +220,7 @@ const isWorldpayTestService = (service: Service, account: GatewayAccount) => {
     service.gatewayAccountIds.length === 1 &&
     account.id === parseInt(service.gatewayAccountIds[0]) &&
     account.type === GatewayAccountType.TEST &&
-    account.paymentProvider === PaymentProviders.WORLDPAY
+    account.paymentProvider === PaymentProvider.WORLDPAY
   )
 }
 

--- a/test/fixtures/gateway-account/credential.fixture.ts
+++ b/test/fixtures/gateway-account/credential.fixture.ts
@@ -8,6 +8,10 @@ export class CredentialFixture {
   public recurringCustomerInitiated?: WorldpayCredentialFixture
   public recurringMerchantInitiated?: WorldpayCredentialFixture
   public googlePayMerchantId?: string
+  public legalEntityId?: string | null
+  public storeId?: string | null
+  public accountHolderId?: string | null
+  public balanceAccountId?: string | null
 
   constructor(...overrides: Partial<CredentialFixture>[]) {
     overrides.forEach((override) => {
@@ -35,6 +39,18 @@ export class CredentialFixture {
 
   static forSandbox() {
     return new CredentialFixture()
+  }
+
+  static forAdyen(...overrides: Partial<CredentialFixture>[]) {
+    return new CredentialFixture(
+      {
+        legalEntityId: null,
+        storeId: null,
+        accountHolderId: null,
+        balanceAccountId: null,
+      },
+      ...overrides
+    )
   }
 
   toCredentialData(): CredentialData {

--- a/test/fixtures/gateway-account/gateway-account-credential.fixture.ts
+++ b/test/fixtures/gateway-account/gateway-account-credential.fixture.ts
@@ -2,10 +2,11 @@ import { GatewayAccountCredentialData } from '@models/gateway-account-credential
 import GatewayAccountCredential from '@models/gateway-account-credential/GatewayAccountCredential.class'
 import { CredentialFixture } from '@test/fixtures/gateway-account/credential.fixture'
 import PaymentProviders from '@models/constants/payment-providers'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 export class GatewayAccountCredentialFixture {
   public externalId: string
-  public paymentProvider: string
+  public paymentProvider: PaymentProvider
   public credentials: CredentialFixture
   public state: string
   public createdDate: string
@@ -55,6 +56,29 @@ export class GatewayAccountCredentialFixture {
       },
       ...overrides
     )
+  }
+
+  static forAdyen(...overrides: Partial<GatewayAccountCredentialFixture>[]) {
+    return new GatewayAccountCredentialFixture(
+      {
+        paymentProvider: PaymentProviders.ADYEN,
+        credentials: CredentialFixture.forAdyen(),
+      },
+      ...overrides
+    )
+  }
+
+  static forProvider(provider: PaymentProvider, ...overrides: Partial<GatewayAccountCredentialFixture>[]) {
+    switch (provider) {
+      case 'stripe':
+        return GatewayAccountCredentialFixture.forStripe(...overrides)
+      case 'worldpay':
+        return GatewayAccountCredentialFixture.forWorldpay(...overrides)
+      case 'adyen':
+        return GatewayAccountCredentialFixture.forAdyen(...overrides)
+      case 'sandbox':
+        return GatewayAccountCredentialFixture.forSandbox(...overrides)
+    }
   }
 
   toGatewayAccountCredentialData(): GatewayAccountCredentialData {

--- a/test/fixtures/gateway-account/gateway-account.fixture.ts
+++ b/test/fixtures/gateway-account/gateway-account.fixture.ts
@@ -4,6 +4,7 @@ import { GatewayAccountCredentialFixture } from '@test/fixtures/gateway-account/
 import { Worldpay3dsFlexCredentialFixture } from '@test/fixtures/gateway-account/worldpay-3ds-flex-credential.fixture'
 import { EmailNotificationFixture } from '@test/fixtures/gateway-account/email-notification.fixture'
 import PaymentProviders from '@models/constants/payment-providers'
+import { PaymentProvider } from '@models/constants/payment-provider'
 
 export class GatewayAccountFixture {
   readonly id: number
@@ -22,7 +23,7 @@ export class GatewayAccountFixture {
   readonly motoMaskCardNumber: boolean
   readonly motoMaskCardSecurityCode: boolean
   readonly name: string
-  readonly paymentProvider: string
+  readonly paymentProvider: PaymentProvider
   readonly providerSwitchEnabled: boolean
   readonly recurringEnabled: boolean
   readonly requires3ds: boolean
@@ -86,6 +87,25 @@ export class GatewayAccountFixture {
 
   static forSandbox(...overrides: Partial<GatewayAccountFixture>[]) {
     return new GatewayAccountFixture(...overrides)
+  }
+
+  static forSwitchingPsp(from: PaymentProvider, to: PaymentProvider, ...overrides: Partial<GatewayAccountFixture>[]) {
+    return new GatewayAccountFixture(
+      {
+        paymentProvider: from,
+        gatewayAccountCredentials: [
+          GatewayAccountCredentialFixture.forProvider(from),
+          GatewayAccountCredentialFixture.forProvider(to, {
+            state: 'CREATED',
+            externalId: 'gateway-account-credential-def-456',
+            createdDate: '2026-01-01T00:00:00.000Z',
+            activeStartDate: undefined,
+          }),
+        ],
+        providerSwitchEnabled: true,
+      },
+      ...overrides
+    )
   }
 
   toGatewayAccountData(): GatewayAccountData {


### PR DESCRIPTION
## What

PP-15746

- Add basic unit tests for switch-to-adyen.controller.test.ts
- Update test fixtures to support Adyen credentials and PSP switching scenarios
- Add stricter typing for PaymentProvider values
  - add payment-provider.ts as progressive replacement for payment-providers.ts, with const and type exports
  - replace uses of payment-providers.ts in some cases
  - handle errors caused by type narrowing from `const` assertion on `PaymentProviders` object
