### PR TITLE
PP-15765: remove npm from deployment image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !package.json
 !package-lock.json
 !types
+!.npmrc
 # exclude tests
 **/*.test.ts
 **/*.test.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
 FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS base
 
-WORKDIR /app
 RUN apk upgrade --no-cache \
     && apk add --no-cache tini
 
-# Upgrade npm — if updating the Node.js version, check if this
-# is still necessary and make sure it never downgrades npm
-RUN npm install -g npm@11.18.0
-
 FROM base AS builder
 
-COPY . .
+WORKDIR /build-stage
+COPY . ./
 RUN npm ci --quiet
 RUN npm run compile
 
 FROM base AS final
 
-COPY --from=builder /app/dist .
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/corepack \
+    /opt/yarn-* \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg
+
+WORKDIR /app
+COPY --from=builder /build-stage/dist ./
 ENV PORT=9000
 EXPOSE 9000
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ FROM base AS builder
 RUN npm install -g npm@11.18.0
 
 WORKDIR /build-stage
-COPY . ./
 RUN npm ci --quiet
+COPY . ./
 RUN npm run compile
 
 FROM base AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN apk upgrade --no-cache \
 
 FROM base AS builder
 
+# Upgrade npm — if updating the Node.js version, check if this
+# is still necessary and make sure it never downgrades npm
+RUN npm install -g npm@11.18.0
+
 WORKDIR /build-stage
 COPY . ./
 RUN npm ci --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ WORKDIR /app
 COPY --from=builder /build-stage/dist ./
 ENV PORT=9000
 EXPOSE 9000
+USER 1000
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "application.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,5 @@ WORKDIR /app
 COPY --from=builder /build-stage/dist ./
 ENV PORT=9000
 EXPOSE 9000
-USER 1000
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "application.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM base AS builder
 RUN npm install -g npm@11.18.0
 
 WORKDIR /build-stage
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci --quiet
 COPY . ./
 RUN npm run compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS base
 
-RUN apk upgrade --no-cache \
-    && apk add --no-cache tini
+RUN apk upgrade --no-cache
 
 FROM base AS builder
 
@@ -16,14 +15,15 @@ RUN npm run compile
 
 FROM base AS final
 
-RUN rm -rf /usr/local/lib/node_modules/npm \
-    /usr/local/lib/node_modules/corepack \
-    /usr/local/bin/npm \
-    /usr/local/bin/npx \
-    /usr/local/bin/corepack \
-    /opt/yarn-* \
-    /usr/local/bin/yarn \
-    /usr/local/bin/yarnpkg
+RUN apk add --no-cache tini \
+    && rm -rf /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack \
+        /opt/yarn-* \
+        /usr/local/bin/yarn \
+        /usr/local/bin/yarnpkg
 
 WORKDIR /app
 COPY --from=builder /build-stage/dist ./


### PR DESCRIPTION
This PR removes npm, corepack and yarn from the final image. The following are removed:

- `/usr/local/lib/node_modules/npm` - the global npm installation
- `/usr/local/lib/node_modules/corepack` - the global corepack installation
- `/usr/local/bin/npm` - symlink to `/usr/local/lib/node_modules/npm/bin/npm-cli.js`
- `/usr/local/bin/npx` - symlink to `/usr/local/lib/node_modules/npm/bin/npx-cli.js`
- `/usr/local/bin/corepack` - symlink to `/usr/local/lib/node_modules/corepack/dist/corepack.js`
- `/opt/yarn-*` - global yarn installation(s)
- `/usr/local/bin/yarn` - symlink to `/opt/yarn-<current-version>/bin/yarn`
- `/usr/local/bin/yarnpkg` - symlink to `/opt/yarn-<current-version>/bin/yarnpkg`

Note that yarn has been [removed from the Node.js 26+ images
](https://github.com/nodejs/docker-node/issues/2264), and corepack is not included from Node 25.

Additionally:
* Uses a WORKDIRs with a more descriptive name in the "builder" stage, for clarity