### PR TITLE
PP-15746 Add Cypress tests for switch-to-adyen task list

### DIFF
--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
@@ -20,7 +20,7 @@ const { req, res, call } = new ControllerTestBuilder(
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
   .withAccount(
-    GatewayAccountFixture.forSwitchingPsp(PaymentProvider.STRIPE, PaymentProvider.ADYEN, {
+    GatewayAccountFixture.forSwitchingPsp(PaymentProvider.STRIPE, PaymentProvider.ADYEN, [], [], {
       type: 'live',
     }).toGatewayAccount()
   )

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/index.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/index.njk
@@ -34,7 +34,7 @@
     })
   }}
 
-  <h2 class="govuk-heading-m">3. Complete your organisation's details</h2>
+  <h2 class="govuk-heading-m">3. Complete your organisation’s details</h2>
 
   {{
     taskList({

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -154,5 +154,4 @@ describe('switch to adyen task list', () => {
         })
     })
   })
-  // describe('page ')
 })

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -1,0 +1,158 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe('switch to adyen task list', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`)
+    checkServiceNavigation(
+      'Switch provider to Adyen now',
+      `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+    )
+
+    cy.title().should(
+      'eq',
+      `Switch your payment provider to Adyen - Settings - Power Plant Safety Inspection - GOV.UK Pay`
+    )
+
+    cy.get('h1').should('contain.text', 'Switch your payment provider to Adyen')
+  })
+
+  describe('for a service that has completed no migration tasks', () => {
+    it('should show the task list with all tasks in the correct state', () => {
+      setStubs()
+
+      cy.visit(`/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`)
+
+      cy.get('h2')
+        .contains('1. Confirm your organisation')
+        .next('.govuk-task-list')
+        .within(() => {
+          cy.get('.govuk-task-list__item').should('have.length', 1)
+
+          cy.get('.govuk-task-list__item')
+            .eq(0)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Organisation details')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+        })
+
+      cy.get('h2')
+        .contains('2. Accept the legal terms')
+        .next('.govuk-task-list')
+        .within(() => {
+          cy.get('.govuk-task-list__item').should('have.length', 1)
+
+          cy.get('.govuk-task-list__item')
+            .eq(0)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Read and accept Adyen’s legal terms')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+        })
+
+      cy.get('h2')
+        .contains('3. Complete your organisation’s details')
+        .next('.govuk-task-list')
+        .within(() => {
+          cy.get('.govuk-task-list__item').should('have.length', 4)
+
+          cy.get('.govuk-task-list__item')
+            .eq(0)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Organisation’s bank details')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+
+          cy.get('.govuk-task-list__item')
+            .eq(1)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Responsible person')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+
+          cy.get('.govuk-task-list__item')
+            .eq(2)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Service director')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+
+          cy.get('.govuk-task-list__item')
+            .eq(3)
+            .within(() => {
+              cy.get('.govuk-task-list__link')
+                .should('contain.text', 'Tell us why your service takes payments')
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+            })
+        })
+    })
+  })
+  // describe('page ')
+})

--- a/test/fixtures/gateway-account/gateway-account.fixture.ts
+++ b/test/fixtures/gateway-account/gateway-account.fixture.ts
@@ -89,18 +89,28 @@ export class GatewayAccountFixture {
     return new GatewayAccountFixture(...overrides)
   }
 
-  static forSwitchingPsp(from: PaymentProvider, to: PaymentProvider, ...overrides: Partial<GatewayAccountFixture>[]) {
+  static forSwitchingPsp(
+    from: PaymentProvider,
+    to: PaymentProvider,
+    fromCredentialOverrides: Partial<GatewayAccountCredentialFixture>[] = [],
+    toCredentialOverrides: Partial<GatewayAccountCredentialFixture>[] = [],
+    ...overrides: Partial<GatewayAccountFixture>[]
+  ) {
     return new GatewayAccountFixture(
       {
         paymentProvider: from,
         gatewayAccountCredentials: [
-          GatewayAccountCredentialFixture.forProvider(from),
-          GatewayAccountCredentialFixture.forProvider(to, {
-            state: 'CREATED',
-            externalId: 'gateway-account-credential-def-456',
-            createdDate: '2026-01-01T00:00:00.000Z',
-            activeStartDate: undefined,
-          }),
+          GatewayAccountCredentialFixture.forProvider(from, ...fromCredentialOverrides),
+          GatewayAccountCredentialFixture.forProvider(
+            to,
+            {
+              state: 'CREATED',
+              externalId: 'gateway-account-credential-def-456',
+              createdDate: '2026-01-01T00:00:00.000Z',
+              activeStartDate: undefined,
+            },
+            ...toCredentialOverrides
+          ),
         ],
         providerSwitchEnabled: true,
       },


### PR DESCRIPTION
### What

PP-15746

- Add basic Cypress tests for "Switch provider to Adyen now" page

These tests are for the task list skeleton, with all tasks currently showing as "Not yet started". As the migration journey is developed, these will need to be updated for the changes in initial task status