### PR TITLE
PP-15743 Implement "Organisation's bank details" task skeleton

### DIFF
--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.test.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.test.js
@@ -1,0 +1,77 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import sinon from 'sinon'
+const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
+const paths = require('@root/paths')
+
+const SERVICE_EXTERNAL_ID = 'service123abc'
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+})
+
+const mockResponse = sinon.stub()
+
+const { req, res, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller'
+)
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withAccount(
+    GatewayAccountFixture.forSwitchingPsp(PaymentProvider.STRIPE, PaymentProvider.ADYEN, [], [], {
+      type: 'live',
+    }).toGatewayAccount()
+  )
+  .withUser(UserFixture.asServiceAdmin([serviceFixture]).toUser())
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('Controller: settings/switch-psp/switch-to-adyen/bank-details', () => {
+  describe('get', () => {
+    it('should call the response function with req, res, and the template path', async () => {
+      await call('get')
+
+      mockResponse.should.have.been.calledOnce
+      mockResponse.should.have.been.calledWith(
+        req,
+        res,
+        'simplified-account/settings/switch-psp/switch-to-adyen/bank-details'
+      )
+    })
+
+    it('should call the response method with the backLink and submitLink', async () => {
+      await call('get')
+
+      mockResponse.should.have.been.calledOnce
+      const context = mockResponse.args[0][3]
+      sinon.assert.match(context, {
+        backLink: formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+          req.service.externalId,
+          req.account.type
+        ),
+        submitLink: formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
+          req.service.externalId,
+          req.account.type
+        ),
+      })
+    })
+  })
+  describe('post', () => {
+    it('should redirect to the switch to adyen task list', async () => {
+      await call('post')
+      sinon.assert.calledOnceWithExactly(
+        res.redirect,
+        formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+          req.service.externalId,
+          req.account.type
+        )
+      )
+    })
+  })
+})

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.test.ts
@@ -4,10 +4,11 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { UserFixture } from '@test/fixtures/user/user.fixture'
 import { ServiceFixture } from '@test/fixtures/service/service.fixture'
 import sinon from 'sinon'
-const formatServiceAndAccountPathsFor = require('@utils/simplified-account/format/format-service-and-account-paths-for')
-const paths = require('@root/paths')
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import paths from '@root/paths'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
+const SERVICE_TYPE = 'live'
 const serviceFixture = new ServiceFixture({
   externalId: SERVICE_EXTERNAL_ID,
 })
@@ -46,17 +47,12 @@ describe('Controller: settings/switch-psp/switch-to-adyen/bank-details', () => {
       await call('get')
 
       mockResponse.should.have.been.calledOnce
-      const context = mockResponse.args[0][3]
+      const context = mockResponse.firstCall.lastArg as { backLink: string }
       sinon.assert.match(context, {
         backLink: formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
-          req.service.externalId,
-          req.account.type
-        ),
-        submitLink: formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
-          req.service.externalId,
-          req.account.type
+          SERVICE_EXTERNAL_ID,
+          SERVICE_TYPE
         ),
       })
     })
@@ -68,8 +64,8 @@ describe('Controller: settings/switch-psp/switch-to-adyen/bank-details', () => {
         res.redirect,
         formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
-          req.service.externalId,
-          req.account.type
+          SERVICE_EXTERNAL_ID,
+          SERVICE_TYPE
         )
       )
     })

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
@@ -1,0 +1,31 @@
+import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import paths from '@root/paths'
+
+async function get(req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/bank-details', {
+    backLink: formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+      req.service.externalId,
+      req.account.type
+    ),
+    submitLink: formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
+      req.service.externalId,
+      req.account.type
+    ),
+  })
+}
+
+async function post(req: ServiceRequest, res: ServiceResponse) {
+  return res.redirect(
+    formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+      req.service.externalId,
+      req.account.type
+    )
+  )
+}
+
+export { get, post }

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
@@ -3,7 +3,7 @@ import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
 
-async function get(req: ServiceRequest, res: ServiceResponse) {
+function get(req: ServiceRequest, res: ServiceResponse) {
   return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/bank-details', {
     backLink: formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
@@ -18,7 +18,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   })
 }
 
-async function post(req: ServiceRequest, res: ServiceResponse) {
+function post(req: ServiceRequest, res: ServiceResponse) {
   return res.redirect(
     formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.controller.ts
@@ -10,11 +10,6 @@ function get(req: ServiceRequest, res: ServiceResponse) {
       req.service.externalId,
       req.account.type
     ),
-    submitLink: formatServiceAndAccountPathsFor(
-      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
-      req.service.externalId,
-      req.account.type
-    ),
   })
 }
 

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/index.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/index.ts
@@ -1,5 +1,6 @@
 import * as index from './switch-to-adyen.controller'
 import * as adyenFees from './adyen-fees.controller'
 import * as providerChangeToAdyenInfo from './provider-change-to-adyen.controller'
+import * as bankDetails from './bank-details.controller'
 
-export { index, adyenFees, providerChangeToAdyenInfo }
+export { index, adyenFees, providerChangeToAdyenInfo, bankDetails }

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -31,7 +31,11 @@ class AdyenTask extends Task {
     return new AdyenTask(
       'Organisation’s bank details',
       AdyenTaskIdentifier.BANK_DETAILS,
-      formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails, service.externalId, gatewayAccount.type)
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
+        service.externalId,
+        gatewayAccount.type
+      )
     ).setStatus(TaskStatus.NOT_STARTED)
   }
 

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -31,7 +31,7 @@ class AdyenTask extends Task {
     return new AdyenTask(
       'Organisation’s bank details',
       AdyenTaskIdentifier.BANK_DETAILS,
-      formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.index, service.externalId, gatewayAccount.type)
+      formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails, service.externalId, gatewayAccount.type)
     ).setStatus(TaskStatus.NOT_STARTED)
   }
 

--- a/src/paths.js
+++ b/src/paths.js
@@ -269,7 +269,7 @@ module.exports = {
           index: '/settings/switch-psp/switch-to-adyen',
           providerChangeToAdyen: '/settings/switch-psp/switch-to-adyen/provider-change-to-adyen',
           adyenFees: '/settings/switch-psp/switch-to-adyen/adyen-fees',
-          bankDetails: '/settings/switch-psp/switch-to-adyen/bank-details'
+          bankDetails: '/settings/switch-psp/switch-to-adyen/bank-details',
         },
         switchToStripe: {
           index: '/settings/switch-psp/switch-to-stripe',

--- a/src/paths.js
+++ b/src/paths.js
@@ -269,6 +269,7 @@ module.exports = {
           index: '/settings/switch-psp/switch-to-adyen',
           providerChangeToAdyen: '/settings/switch-psp/switch-to-adyen/provider-change-to-adyen',
           adyenFees: '/settings/switch-psp/switch-to-adyen/adyen-fees',
+          bankDetails: '/settings/switch-psp/switch-to-adyen/bank-details'
         },
         switchToStripe: {
           index: '/settings/switch-psp/switch-to-stripe',

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -825,6 +825,20 @@ simplifiedAccount.get(
   serviceSettingsController.switchPsp.switchToAdyen.adyenFees.get
 )
 simplifiedAccount.get(
+  paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.switchPsp.switchToAdyen.bankDetails.get
+)
+simplifiedAccount.post(
+  paths.simplifiedAccount.settings.switchPsp.switchToAdyen.bankDetails,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.switchPsp.switchToAdyen.bankDetails.post
+)
+simplifiedAccount.get(
   paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
   restrictToSwitchingAccount(WORLDPAY),
   permission('gateway-credentials:update'),

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
@@ -3,7 +3,7 @@
 {% set settingsPageTitle = 'Organisation’s bank details' %}
 
 {% block settingsContent %}
-  <form id="bank-details-form" autocomplete="off" method="post" action="{{ submitLink }}" class="govuk-!-margin-top-3">
+  <form id="bank-details-form" autocomplete="off" method="post" class="govuk-!-margin-top-3">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
     {%
       call govukFieldset({

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
@@ -1,10 +1,9 @@
 {% extends "simplified-account/settings/settings-layout.njk" %}
 
-
-{% set settingsPageTitle = 'Organisation’s bank details'%}
+{% set settingsPageTitle = 'Organisation’s bank details' %}
 
 {% block settingsContent %}
-  <form id="bank-details-form" autocomplete="off" method="post" action="{{ submitLink }}" class="govuk-!-margin-top-3"> 
+  <form id="bank-details-form" autocomplete="off" method="post" action="{{ submitLink }}" class="govuk-!-margin-top-3">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
     {%
       call govukFieldset({

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/bank-details.njk
@@ -1,0 +1,73 @@
+{% extends "simplified-account/settings/settings-layout.njk" %}
+
+
+{% set settingsPageTitle = 'Organisation’s bank details'%}
+
+{% block settingsContent %}
+  <form id="bank-details-form" autocomplete="off" method="post" action="{{ submitLink }}" class="govuk-!-margin-top-3"> 
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+    {%
+      call govukFieldset({
+        legend: {
+          text: "Organisation’s bank details",
+          classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6",
+          isPageHeading: true
+        }
+      })
+    %}
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        Adyen will use these details to pay money from GOV.UK Pay transactions into your organisation's bank account.</p
+      >
+
+      <p class="govuk-body govuk-!-margin-bottom-6"> The account must be held in your organisation's name.</p>
+
+      {{
+        govukInput({
+          label: {
+            text: "Sort code"
+          },
+          classes: "govuk-!-width-one-quarter",
+          id: "sort-code",
+          name: "sortCode",
+          inputmode: "numeric",
+          value: sortCode,
+          errorMessage: { text: errors.formErrors['sortCode'] } if errors.formErrors['sortCode'] else false,
+          hint: {
+            text: "Must be 6 digits long"
+          },
+          attributes: {
+            maxlength: "8"
+          }
+        })
+      }}
+
+      {{
+        govukInput({
+          label: {
+            text: "Account number"
+          },
+          classes: "govuk-!-width-one-quarter",
+          id: "account-number",
+          name: "accountNumber",
+          inputmode: "numeric",
+          value: accountNumber,
+          errorMessage: { text: errors.formErrors['accountNumber'] } if errors.formErrors['accountNumber'] else false,
+          hint: {
+            text: "Must be between 6 and 8 digits long"
+          },
+          attributes: {
+            maxlength: "8"
+          }
+        })
+      }}
+
+      {{
+        govukButton({
+          id: "bank-details-submit",
+          text: "Continue",
+          preventDoubleClick: true
+        })
+      }}
+    {% endcall %}
+  </form>
+{% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -121,7 +121,7 @@ describe('switch to adyen task list', () => {
             .within(() => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Organisation’s bank details')
-                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen/bank-details`)
               cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
             })
 

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -121,7 +121,11 @@ describe('switch to adyen task list', () => {
             .within(() => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Organisation’s bank details')
-                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen/bank-details`)
+                .should(
+                  'have.attr',
+                  'href',
+                  `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen/bank-details`
+                )
               cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
             })
 


### PR DESCRIPTION
## What

[PP-**[15743]**](https://payments-platform.atlassian.net/browse/PP-15749)

- Added get and post controllers for bank-details and added path to routes.
- Added view in bank-details.njk matching design linked in ticket

For now as this is a skeleton the form does not submit anything to Adyen and there is no validation. That will come in later tickets. 

I will put cypress tests for this work in another PR. 

<img width="1167" height="795" alt="image" src="https://github.com/user-attachments/assets/2eca7d9b-eadf-42ab-9647-c50943e32385" />
