### PR TITLE
PP-15746 Add Cypress tests for scenarios where service is not switching to Adyen

### DIFF
--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -23,13 +23,13 @@ const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
   ],
   {
     id: GATEWAY_ACCOUNT_ID,
-    type: LIVE_ACCOUNT_TYPE,
     serviceId: SERVICE_EXTERNAL_ID,
   }
 )
 const serviceFixture = new ServiceFixture({
   externalId: SERVICE_EXTERNAL_ID,
   gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+  currentGoLiveStage: 'LIVE',
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
@@ -156,6 +156,84 @@ describe('switch to adyen task list', () => {
               cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
             })
         })
+    })
+  })
+
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+      beforeEach(() => {
+        cy.task('clearStubs')
+
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view the task list', () => {
+        cy.request({
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/live/settings/switch-psp/switch-to-adyen`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
+
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view the task list', () => {
+        cy.request({
+          url: `/service/${SERVICE_EXTERNAL_ID}/account/live/settings/switch-psp/switch-to-adyen`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
     })
   })
 })

--- a/test/fixtures/gateway-account/gateway-account.fixture.ts
+++ b/test/fixtures/gateway-account/gateway-account.fixture.ts
@@ -3,8 +3,8 @@ import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
 import { GatewayAccountCredentialFixture } from '@test/fixtures/gateway-account/gateway-account-credential.fixture'
 import { Worldpay3dsFlexCredentialFixture } from '@test/fixtures/gateway-account/worldpay-3ds-flex-credential.fixture'
 import { EmailNotificationFixture } from '@test/fixtures/gateway-account/email-notification.fixture'
-import PaymentProviders from '@models/constants/payment-providers'
 import { PaymentProvider } from '@models/constants/payment-provider'
+import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 
 export class GatewayAccountFixture {
   readonly id: number
@@ -50,7 +50,7 @@ export class GatewayAccountFixture {
     this.motoMaskCardNumber = false
     this.motoMaskCardSecurityCode = false
     this.name = 'Test Account'
-    this.paymentProvider = PaymentProviders.SANDBOX
+    this.paymentProvider = PaymentProvider.SANDBOX
     this.providerSwitchEnabled = false
     this.recurringEnabled = false
     this.requires3ds = false
@@ -68,7 +68,7 @@ export class GatewayAccountFixture {
   static forStripe(...overrides: Partial<GatewayAccountFixture>[]) {
     return new GatewayAccountFixture(
       {
-        paymentProvider: PaymentProviders.STRIPE,
+        paymentProvider: PaymentProvider.STRIPE,
         gatewayAccountCredentials: [GatewayAccountCredentialFixture.forStripe()],
       },
       ...overrides
@@ -78,7 +78,7 @@ export class GatewayAccountFixture {
   static forWorldpay(...overrides: Partial<GatewayAccountFixture>[]) {
     return new GatewayAccountFixture(
       {
-        paymentProvider: PaymentProviders.WORLDPAY,
+        paymentProvider: PaymentProvider.WORLDPAY,
         gatewayAccountCredentials: [GatewayAccountCredentialFixture.forWorldpay()],
       },
       ...overrides
@@ -87,6 +87,16 @@ export class GatewayAccountFixture {
 
   static forSandbox(...overrides: Partial<GatewayAccountFixture>[]) {
     return new GatewayAccountFixture(...overrides)
+  }
+
+  static forAdyen(...overrides: Partial<GatewayAccountFixture>[]) {
+    return new GatewayAccountFixture(
+      {
+        paymentProvider: PaymentProvider.ADYEN,
+        gatewayAccountCredentials: [GatewayAccountCredentialFixture.forAdyen()],
+      },
+      ...overrides
+    )
   }
 
   static forSwitchingPsp(
@@ -113,6 +123,7 @@ export class GatewayAccountFixture {
           ),
         ],
         providerSwitchEnabled: true,
+        type: GatewayAccountType.LIVE,
       },
       ...overrides
     )


### PR DESCRIPTION
## What

PP-15746
Add Cypress tests for scenarios where service is not switching to Adyen

- Add Cypress test for service switching to a different provider
- Add Cypress test for service already live with Adyen
