### PR TITLE
PP-15749 Add cypress tests for Organisation's Bank Details page

### DIFF
--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/bank-details.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/bank-details.cy.ts
@@ -46,7 +46,7 @@ const setStubs = (additionalStubs = []) => {
   ])
 }
 
-describe('switch to adyen task list', () => {
+describe(`Organisation's bank details`, () => {
   beforeEach(() => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
   })
@@ -67,32 +67,112 @@ describe('switch to adyen task list', () => {
     cy.get('h1').should('contain.text', `Organisation’s bank details`)
   })
 
-  it('should display a back link to the switch-to-adyen task list', () => {
-    setStubs()
+  describe('for a service that is migrating to adyen', () => {
+    it('should display a back link to the switch-to-adyen task list', () => {
+      setStubs()
 
-    cy.visit(BANK_DETAILS_PATH)
+      cy.visit(BANK_DETAILS_PATH)
 
-    cy.get('.govuk-back-link').should('have.attr', 'href', TASK_LIST_PATH)
+      cy.get('.govuk-back-link').should('have.attr', 'href', TASK_LIST_PATH)
+    })
+
+    it('should display sort code and account number inputs', () => {
+      setStubs()
+
+      cy.visit(BANK_DETAILS_PATH)
+
+      cy.get('#sort-code').should('exist')
+      cy.get('#account-number').should('exist')
+    })
+
+    it('should redirect to the task list when continue is pressed', () => {
+      setStubs()
+
+      cy.visit(BANK_DETAILS_PATH)
+
+      cy.get('#sort-code').type('123456')
+      cy.get('#account-number').type('12345678')
+      cy.get('#bank-details-submit').click()
+
+      cy.location('pathname').should('eq', TASK_LIST_PATH)
+    })
   })
 
-  it('should display sort code and account number inputs', () => {
-    setStubs()
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
 
-    cy.visit(BANK_DETAILS_PATH)
+      beforeEach(() => {
+        cy.task('clearStubs')
 
-    cy.get('#sort-code').should('exist')
-    cy.get('#account-number').should('exist')
-  })
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
 
-  it('should redirect to the task list when continue is pressed', () => {
-    setStubs()
+      it('should return a 404 when attempting to view bank details', () => {
+        cy.request({
+          url: BANK_DETAILS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
 
-    cy.visit(BANK_DETAILS_PATH)
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
 
-    cy.get('#sort-code').type('123456')
-    cy.get('#account-number').type('12345678')
-    cy.get('#bank-details-submit').click()
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
-    cy.location('pathname').should('eq', TASK_LIST_PATH)
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view bank details', () => {
+        cy.request({
+          url: BANK_DETAILS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
   })
 })

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/bank-details.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/bank-details.cy.ts
@@ -1,0 +1,98 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const BANK_DETAILS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen/bank-details`
+const TASK_LIST_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe('switch to adyen task list', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(BANK_DETAILS_PATH)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(BANK_DETAILS_PATH)
+
+    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+    cy.get('h1').should('contain.text', `Organisation’s bank details`)
+  })
+
+  it('should display a back link to the switch-to-adyen task list', () => {
+    setStubs()
+
+    cy.visit(BANK_DETAILS_PATH)
+
+    cy.get('.govuk-back-link').should('have.attr', 'href', TASK_LIST_PATH)
+  })
+
+  it('should display sort code and account number inputs', () => {
+    setStubs()
+
+    cy.visit(BANK_DETAILS_PATH)
+
+    cy.get('#sort-code').should('exist')
+    cy.get('#account-number').should('exist')
+  })
+
+  it('should redirect to the task list when continue is pressed', () => {
+    setStubs()
+
+    cy.visit(BANK_DETAILS_PATH)
+
+    cy.get('#sort-code').type('123456')
+    cy.get('#account-number').type('12345678')
+    cy.get('#bank-details-submit').click()
+
+    cy.location('pathname').should('eq', TASK_LIST_PATH)
+  })
+})


### PR DESCRIPTION
## What

**[PP-15749](https://payments-platform.atlassian.net/browse/PP-15749)**

- Add cypress tests for 'Organisation's Bank Details' page - viewable and intractable when service is migrating to Adyen. 
- Add cypress tests for 'Organisation's Bank Details' page - not viewable and returns 404 when service is not migrating to Adyen.

The page is just a skeleton for now, so tests may need updating once the page has more functionality in future tickets.

[PP-15749]: https://payments-platform.atlassian.net/browse/PP-15749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ