### PR TITLE
PP-15752 reason for payments - complete skeleton page

### DIFF
--- a/src/controllers/simplified-account/settings/adyen-details/index.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/index.ts
@@ -1,4 +1,5 @@
 import * as bankDetails from './bank-details.controller'
 import * as legalTerms from './legal-terms.controller'
+import * as reasonForTakingPayments from './reason-for-taking-payments.controller'
 
-export { bankDetails, legalTerms }
+export { bankDetails, legalTerms, reasonForTakingPayments }

--- a/src/controllers/simplified-account/settings/adyen-details/reason-for-taking-payments.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/reason-for-taking-payments.controller.test.ts
@@ -16,7 +16,7 @@ const serviceFixture = new ServiceFixture({
 const mockResponse = sinon.stub()
 
 const { req, res, call } = new ControllerTestBuilder(
-  '@controllers/simplified-account/settings/switch-psp/switch-to-adyen/reason-for-taking-payments.controller'
+  '@controllers/simplified-account/settings/adyen-details/reason-for-taking-payments.controller'
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
   .withAccount(
@@ -30,7 +30,7 @@ const { req, res, call } = new ControllerTestBuilder(
   })
   .build()
 
-describe('Controller: settings/switch-psp/switch-to-adyen/reason-for-taking-payments', () => {
+describe('Controller: settings/adyen-details/reason-for-taking-payments', () => {
   describe('get', () => {
     it('should call the response function with req, res, and the template path', async () => {
       await call('get')
@@ -39,7 +39,7 @@ describe('Controller: settings/switch-psp/switch-to-adyen/reason-for-taking-paym
       mockResponse.should.have.been.calledWith(
         req,
         res,
-        'simplified-account/settings/switch-psp/switch-to-adyen/reason-for-taking-payments'
+        'simplified-account/settings/adyen-details/reason-for-taking-payments'
       )
     })
 

--- a/src/controllers/simplified-account/settings/adyen-details/reason-for-taking-payments.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/reason-for-taking-payments.controller.ts
@@ -4,7 +4,7 @@ import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/fo
 import paths from '@root/paths'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
-  return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/reason-for-taking-payments', {
+  return response(req, res, 'simplified-account/settings/adyen-details/reason-for-taking-payments', {
     backLink: formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
       req.service.externalId,

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -63,10 +63,17 @@ class AdyenTask extends Task {
   }
 
   static reasonForTakingPaymentsTask(service: Service, gatewayAccount: GatewayAccount) {
+    const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
+
     return new AdyenTask(
       'Tell us why your service takes payments',
       AdyenTaskIdentifier.REASON_FOR_TAKING_PAYMENTS,
-      formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.index, service.externalId, gatewayAccount.type)
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.adyenDetails.reasonForTakingPayments,
+        service.externalId,
+        gatewayAccount.type,
+        switchingCredentialId
+      )
     ).setStatus(TaskStatus.NOT_STARTED)
   }
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -306,6 +306,7 @@ module.exports = {
       adyenDetails: {
         bankDetails: '/settings/adyen-details/:credentialId/bank-details',
         legalTerms: '/settings/adyen-details/:credentialId/legal-terms',
+        reasonForTakingPayments: '/settings/adyen-details/:credentialId/reason-for-taking-payments',
       },
     },
   },

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -956,6 +956,22 @@ simplifiedAccount.post(
   serviceSettingsController.adyenDetails.legalTerms.post
 )
 
+simplifiedAccount.get(
+  paths.simplifiedAccount.settings.adyenDetails.reasonForTakingPayments,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.adyenDetails.reasonForTakingPayments.get
+)
+
+simplifiedAccount.post(
+  paths.simplifiedAccount.settings.adyenDetails.reasonForTakingPayments,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.adyenDetails.reasonForTakingPayments.post
+)
+
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true }).use(

--- a/src/views/simplified-account/settings/adyen-details/reason-for-taking-payments.njk
+++ b/src/views/simplified-account/settings/adyen-details/reason-for-taking-payments.njk
@@ -1,0 +1,30 @@
+{% extends "simplified-account/settings/settings-layout.njk" %}
+
+{% set settingsPageTitle = 'What will your service be taking payments for?' %}
+
+{% block settingsContent %}
+  <form id="reason-for-taking-payments-form" autocomplete="off" method="post" class="govuk-!-margin-top-3">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+
+    {{
+      govukCharacterCount({
+        id: "reason-for-taking-payments-textarea",
+        name: "address",
+        maxlength: 140,
+        label: {
+          text: "What will your service be taking payments for?",
+          classes: "govuk-label--l",
+          isPageHeading: true
+        }
+      })
+    }}
+
+    {{
+      govukButton({
+        id: "reason-for-taking-payments-submit",
+        text: "Confirm and submit",
+        preventDoubleClick: true
+      })
+    }}
+  </form>
+{% endblock %}

--- a/src/views/simplified-account/settings/settings-layout.njk
+++ b/src/views/simplified-account/settings/settings-layout.njk
@@ -2,6 +2,7 @@
 {% from "macro/system-messages.njk" import systemMessages %}
 {% from "govuk/components/task-list/macro.njk" import govukTaskList %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {% block pageTitle %}
   {{ settingsPageTitle }}

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/reason-for-taking-payments.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/reason-for-taking-payments.cy.ts
@@ -1,0 +1,176 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const REASON_FOR_TAKING_PAYMENTS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/reason-for-taking-payments`
+const TASK_LIST_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe(`Reason for taking payments`, () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(REASON_FOR_TAKING_PAYMENTS_PATH)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(REASON_FOR_TAKING_PAYMENTS_PATH)
+
+    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+    cy.get('h1').should('contain.text', `What will your service be taking payments for?`)
+  })
+
+  describe('for a service that is migrating to adyen', () => {
+    it('should display a back link to the switch-to-adyen task list', () => {
+      setStubs()
+
+      cy.visit(REASON_FOR_TAKING_PAYMENTS_PATH)
+
+      cy.get('.govuk-back-link').should('have.attr', 'href', TASK_LIST_PATH)
+    })
+
+    it('should display the text area to allow the user to enter the reason', () => {
+      setStubs()
+
+      cy.visit(REASON_FOR_TAKING_PAYMENTS_PATH)
+
+      cy.get('#reason-for-taking-payments-textarea').should('exist')
+    })
+
+    it('should redirect to the task list when continue is pressed', () => {
+      setStubs()
+
+      cy.visit(REASON_FOR_TAKING_PAYMENTS_PATH)
+
+      cy.get('#reason-for-taking-payments-textarea').type('Test reason for taking payments')
+      cy.get('#reason-for-taking-payments-submit').click()
+
+      cy.location('pathname').should('eq', TASK_LIST_PATH)
+    })
+  })
+
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+      beforeEach(() => {
+        cy.task('clearStubs')
+
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
+
+      it(`should return a 404 when attempting to view 'reason for taking payments' page`, () => {
+        cy.request({
+          url: REASON_FOR_TAKING_PAYMENTS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
+
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it(`should return a 404 when attempting to view 'reason for taking payments' page`, () => {
+        cy.request({
+          url: REASON_FOR_TAKING_PAYMENTS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -156,7 +156,11 @@ describe('switch to adyen task list', () => {
             .within(() => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Tell us why your service takes payments')
-                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+                .should(
+                  'have.attr',
+                  'href',
+                  `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/reason-for-taking-payments`
+                )
               cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
             })
         })


### PR DESCRIPTION
## What

PP-**15752**

<img width="804" height="452" alt="image" src="https://github.com/user-attachments/assets/9a35a004-25bc-42f4-9197-9f0ecc9e876d" />

- This PR add the files required to complete the skeleton page for 'reason for taking payments'.
- The Cypress tests are also added as part of this PR.
- Updates to the controllers:
  - Fix the paths used.
  - Move controllers to the correct folder under settings


### How
- Find the service where it is in the process of switching to Adyen
- From the task list - make sure you can access the `Reason for Taking Payments` page from there
- When you press the `confirm and submit` button, it should take you back to the task list
- Make sure Cypress tests are working.