### PR TITLE
PP-15751 Implement service director details get controller and view

### DIFF
--- a/src/controllers/simplified-account/settings/adyen-details/bank-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/bank-details.controller.test.ts
@@ -39,7 +39,7 @@ describe('Controller: settings/adyen-details/bank-details', () => {
       mockResponse.should.have.been.calledWith(req, res, 'simplified-account/settings/adyen-details/bank-details')
     })
 
-    it('should call the response method with the backLink and submitLink', async () => {
+    it('should call the response method with the backLink', async () => {
       await call('get')
 
       mockResponse.should.have.been.calledOnce

--- a/src/controllers/simplified-account/settings/adyen-details/index.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/index.ts
@@ -2,5 +2,7 @@ import * as responsiblePerson from './responsible-person'
 import * as bankDetails from './bank-details.controller'
 import * as legalTerms from './legal-terms.controller'
 import * as reasonForTakingPayments from './reason-for-taking-payments.controller'
+import * as serviceDirector from './service-director/index'
+import * as serviceDirector from './service-director'
 
-export { responsiblePerson, bankDetails, legalTerms, reasonForTakingPayments }
+export { responsiblePerson, bankDetails, legalTerms, reasonForTakingPayments, serviceDirector, serviceDirector }

--- a/src/controllers/simplified-account/settings/adyen-details/index.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/index.ts
@@ -2,7 +2,6 @@ import * as responsiblePerson from './responsible-person'
 import * as bankDetails from './bank-details.controller'
 import * as legalTerms from './legal-terms.controller'
 import * as reasonForTakingPayments from './reason-for-taking-payments.controller'
-import * as serviceDirector from './service-director/index'
 import * as serviceDirector from './service-director'
 
-export { responsiblePerson, bankDetails, legalTerms, reasonForTakingPayments, serviceDirector, serviceDirector }
+export { responsiblePerson, bankDetails, legalTerms, reasonForTakingPayments, serviceDirector }

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/index.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/index.ts
@@ -1,0 +1,3 @@
+import * as details from './service-director-details.controller'
+
+export { details }

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
@@ -1,0 +1,60 @@
+import ControllerTestBuilder from '@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import sinon from 'sinon'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import paths from '@root/paths'
+
+const SERVICE_EXTERNAL_ID = 'service123abc'
+const SERVICE_TYPE = 'live'
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+})
+
+const mockResponse = sinon.stub()
+
+const { req, res, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller'
+)
+  .withServiceExternalId(SERVICE_EXTERNAL_ID)
+  .withAccount(
+    GatewayAccountFixture.forSwitchingPsp(PaymentProvider.STRIPE, PaymentProvider.ADYEN, [], [], {
+      type: 'live',
+    }).toGatewayAccount()
+  )
+  .withUser(UserFixture.asServiceAdmin([serviceFixture]).toUser())
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+  })
+  .build()
+
+describe('Controller: settings/adyen-details/service-director/service-director-details', () => {
+  describe('get', () => {
+    it('should call the response function with req, res, and the template path', async () => {
+      await call('get')
+
+      mockResponse.should.have.been.calledOnce
+      mockResponse.should.have.been.calledWith(
+        req,
+        res,
+        'simplified-account/settings/adyen-details/service-director/details'
+      )
+    })
+
+    it('should call the response method with the backLink', async () => {
+      await call('get')
+
+      mockResponse.should.have.been.calledOnce
+      const context = mockResponse.firstCall.lastArg as { backLink: string }
+      sinon.assert.match(context, {
+        backLink: formatServiceAndAccountPathsFor(
+          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+          SERVICE_EXTERNAL_ID,
+          SERVICE_TYPE
+        ),
+      })
+    })
+  })
+})

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
@@ -1,0 +1,16 @@
+import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import paths from '@root/paths'
+
+function get(req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/settings/adyen-details/service-director/details', {
+    backLink: formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+      req.service.externalId,
+      req.account.type
+    ),
+  })
+}
+
+export { get }

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -62,10 +62,16 @@ class AdyenTask extends Task {
   }
 
   static serviceDirectorTask(service: Service, gatewayAccount: GatewayAccount) {
+    const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
     return new AdyenTask(
       'Service director',
       AdyenTaskIdentifier.SERVICE_DIRECTOR,
-      formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.index, service.externalId, gatewayAccount.type)
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+        service.externalId,
+        gatewayAccount.type,
+        switchingCredentialId
+      )
     ).setStatus(TaskStatus.NOT_STARTED)
   }
 

--- a/src/paths.js
+++ b/src/paths.js
@@ -310,6 +310,9 @@ module.exports = {
           contactDetails: '/settings/adyen-details/:credentialId/responsible-person/contact-details',
           checkYourAnswers: '/settings/adyen-details/:credentialId/responsible-person/check-your-answers',
         },
+        serviceDirector: {
+          details: '/settings/adyen-details/:credentialId/service-director/details',
+        },
         bankDetails: '/settings/adyen-details/:credentialId/bank-details',
         legalTerms: '/settings/adyen-details/:credentialId/legal-terms',
         reasonForTakingPayments: '/settings/adyen-details/:credentialId/reason-for-taking-payments',

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -1028,6 +1028,14 @@ simplifiedAccount.post(
   serviceSettingsController.adyenDetails.reasonForTakingPayments.post
 )
 
+simplifiedAccount.get(
+  paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.adyenDetails.serviceDirector.details.get
+)
+
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true }).use(

--- a/src/views/simplified-account/settings/adyen-details/service-director/details.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/details.njk
@@ -1,0 +1,107 @@
+{% extends "simplified-account/settings/settings-layout.njk" %}
+
+{% set settingsPageTitle = 'Service director details' %}
+
+{% block settingsContent %}
+  <form id="bank-details-form" autocomplete="off" method="post" class="govuk-!-margin-top-3">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+    {%
+      call govukFieldset({
+        legend: {
+          text: settingsPageTitle,
+          classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6",
+          isPageHeading: true
+        }
+      })
+    %}
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        Adyen needs details of the director of the service or someone at director level in your organisation.</p
+      >
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        <a
+          class="govuk-link"
+          href="https://www.payments.service.gov.uk/required-responsible-person-and-director-information/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Check who can be a service director (opens in new tab)
+        </a>
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        If your organisation does not have someone in one of these roles, email
+        <a
+          class="govuk-link govuk-link--no-visited-state"
+          href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk"
+        >
+          govuk-pay-support@digital.cabinet-office.gov.uk </a
+        >. Adyen may accept another senior person who is authorised to transfer funds for the organisation.
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        The service director must be different from the responsible person.
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        This information will be held securely and will not be shared with anyone unnecessarily.
+      </p>
+
+      {{
+        govukInput({
+          label: {
+            text: "First name"
+          },
+          id: "first-name",
+          name: "firstName",
+          value: name.firstName,
+          type: "text",
+          autocomplete: "given-name",
+          spellcheck: false,
+          errorMessage: { text: errors.formErrors['firstName'] } if errors.formErrors['firstName'] else false,
+          classes: "govuk-!-width-three-quarters"
+        })
+      }}
+
+      {{
+        govukInput({
+          label: {
+            text: "Last name"
+          },
+          id: "last-name",
+          name: "lastName",
+          value: name.lastName,
+          type: "text",
+          autocomplete: "family-name",
+          spellcheck: false,
+          errorMessage: { text: errors.formErrors['lastName'] } if errors.formErrors['lastName'] else false,
+          classes: "govuk-!-width-three-quarters"
+        })
+      }}
+      {% include "simplified-account/settings/partials/_dob.njk" %}
+
+      {{
+        govukInput({
+          label: {
+            text: "Email address"
+          },
+          id: "email",
+          name: "email",
+          value: contact.email,
+          type: "email",
+          autocomplete: "email",
+          spellcheck: false,
+          errorMessage: { text: errors.formErrors['email'] } if errors.formErrors['email'] else false,
+          classes: "govuk-!-full-width"
+        })
+      }}
+
+      {{
+        govukButton({
+          id: "service-director-details-submit",
+          text: "Continue",
+          preventDoubleClick: true
+        })
+      }}
+    {% endcall %}
+  </form>
+{% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -151,7 +151,11 @@ describe('switch to adyen task list', () => {
             .within(() => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Service director')
-                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+                .should(
+                  'have.attr',
+                  'href',
+                  `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/details`
+                )
               cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
             })
 


### PR DESCRIPTION
## What

[PP-**[15751]**](https://payments-platform.atlassian.net/browse/PP-15751)

First PR for this ticket. It covers 

- Added get controller and view for service director details (first of three pages for this section).
- Updated path and route.
- Created new sub folders for service director in controllers, views as there will be more pages added in future PRs.
- Amended test description from previous ticket (removed submitlink)
- Unit test for get controller
- Updated cypress test for task lisk page 

Future PR's will cover 
- Post controller for details page and what happens when pressing continue (no functionality in this ticket as yet).
- Next two view pages as per design, plus controllers, paths and route.
- Cypress tests for all views.


<img width="1150" height="988" alt="image" src="https://github.com/user-attachments/assets/ebbeb7ea-6554-45f1-9022-d08da4c74879" />
