### PR TITLE
PP-15751 Add service director address view task skeleton

### DIFF
--- a/src/controllers/simplified-account/settings/adyen-details/service-director/index.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/index.ts
@@ -1,3 +1,4 @@
 import * as details from './service-director-details.controller'
+import * as address from './service-director-address.controller'
 
-export { details }
+export { details, address }

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
@@ -19,7 +19,7 @@ const GATEWAY_ACCOUNT = GatewayAccountFixture.forSwitchingPsp(PaymentProvider.ST
 const mockResponse = sinon.stub()
 
 const { req, res, call } = new ControllerTestBuilder(
-  '@controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller'
+  '@controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller'
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
   .withAccount(GATEWAY_ACCOUNT)
@@ -29,7 +29,7 @@ const { req, res, call } = new ControllerTestBuilder(
   })
   .build()
 
-describe('Controller: settings/adyen-details/service-director/service-director-details', () => {
+describe('Controller: settings/adyen-details/service-director/service-director-address', () => {
   describe('get', () => {
     it('should call the response function with req, res, and the template path', async () => {
       await call('get')
@@ -38,7 +38,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
       mockResponse.should.have.been.calledWith(
         req,
         res,
-        'simplified-account/settings/adyen-details/service-director/details'
+        'simplified-account/settings/adyen-details/service-director/address'
       )
     })
 
@@ -49,25 +49,11 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
       const context = mockResponse.firstCall.lastArg as { backLink: string }
       sinon.assert.match(context, {
         backLink: formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+          paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
           SERVICE_EXTERNAL_ID,
           SERVICE_TYPE
         ),
       })
-    })
-  })
-  describe('post', () => {
-    it('should redirect to the service director address', async () => {
-      await call('post')
-      sinon.assert.calledOnceWithExactly(
-        res.redirect,
-        formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
-          SERVICE_EXTERNAL_ID,
-          SERVICE_TYPE,
-          GATEWAY_ACCOUNT.getSwitchingCredential().externalId
-        )
-      )
     })
   })
 })

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
@@ -1,0 +1,16 @@
+import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
+import paths from '@root/paths'
+
+function get(req: ServiceRequest, res: ServiceResponse) {
+  return response(req, res, 'simplified-account/settings/adyen-details/service-director/address', {
+    backLink: formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+      req.service.externalId,
+      req.account.type
+    ),
+  })
+}
+
+export { get }

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
@@ -13,4 +13,18 @@ function get(req: ServiceRequest, res: ServiceResponse) {
   })
 }
 
-export { get }
+function post(req: ServiceRequest, res: ServiceResponse) {
+  const { account } = req
+  const switchingCredentialId = account.getSwitchingCredential().externalId
+
+  return res.redirect(
+    formatServiceAndAccountPathsFor(
+      paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
+      req.service.externalId,
+      req.account.type,
+      switchingCredentialId
+    )
+  )
+}
+
+export { get, post }

--- a/src/paths.js
+++ b/src/paths.js
@@ -312,6 +312,7 @@ module.exports = {
         },
         serviceDirector: {
           details: '/settings/adyen-details/:credentialId/service-director/details',
+          address: '/settings/adyen-details/:credentialId/service-director/address',
         },
         bankDetails: '/settings/adyen-details/:credentialId/bank-details',
         legalTerms: '/settings/adyen-details/:credentialId/legal-terms',

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -1036,6 +1036,22 @@ simplifiedAccount.get(
   serviceSettingsController.adyenDetails.serviceDirector.details.get
 )
 
+simplifiedAccount.post(
+  paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.adyenDetails.serviceDirector.details.post
+)
+
+simplifiedAccount.get(
+  paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
+  enforceLiveAccountOnly,
+  restrictToSwitchingAccount(ADYEN),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.adyenDetails.serviceDirector.address.get
+)
+
 // stripe details
 const stripeDetailsPath = paths.simplifiedAccount.settings.stripeDetails
 const stripeDetailsRouter = new Router({ mergeParams: true }).use(

--- a/src/views/simplified-account/settings/adyen-details/service-director/address.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/address.njk
@@ -1,0 +1,75 @@
+{% extends "../../settings-layout.njk" %}
+
+{% set settingsPageTitle = "Service director's address" %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+  <form id="responsible-person-address-form" method="post" novalidate>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}" />
+    {% call govukFieldset({}) %}
+      <p class="govuk-body"
+        >Do not use a work address. Adyen needs the service director’s home address to check their identity.</p
+      >
+      {{
+        govukInput({
+          label: {
+            html: 'Address line 1'
+          },
+          id: "address-line1",
+          name: "addressLine1",
+          value: address.homeAddressLine1,
+          type: "text",
+          autocomplete: "address-line1",
+          errorMessage: { text: errors.formErrors['addressLine1'] } if errors.formErrors['addressLine1'] else false,
+          classes: "govuk-!-width-two-thirds"
+        })
+      }}
+      {{
+        govukInput({
+          label: {
+            html: 'Address line 2 (optional)'
+          },
+          id: "address-line2",
+          name: "addressLine2",
+          value: address.addressLine2,
+          type: "text",
+          autocomplete: "address-line2",
+          errorMessage: { text: errors.formErrors['addressLine2'] } if errors.formErrors['addressLine2'] else false,
+          attributes: {
+            "aria-label": "Enter address line 2"
+          },
+          classes: "govuk-!-width-three-quarters"
+        })
+      }}
+      {{
+        govukInput({
+          label: {
+            text: "Town or city"
+          },
+          id: "address-city",
+          name: "addressCity",
+          value: address.addressCity,
+          type: "text",
+          autocomplete: "address-level2",
+          errorMessage: { text: errors.formErrors['addressCity'] } if errors.formErrors['addressCity'] else false,
+          classes: "govuk-!-width-one-half"
+        })
+      }}
+      {{
+        govukInput({
+          label: {
+            text: "Postcode"
+          },
+          id: "address-postcode",
+          name: "addressPostcode",
+          value: address.addressPostcode,
+          type: "text",
+          autocomplete: "postal-code",
+          classes: "govuk-!-width-one-third",
+          errorMessage: { text: errors.formErrors['addressPostcode'] } if errors.formErrors['addressPostcode'] else false
+        })
+      }}
+    {% endcall %}
+    {{ govukButton({ text: "Continue" }) }}
+  </form>
+{% endblock %}

--- a/src/views/simplified-account/settings/adyen-details/service-director/details.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/details.njk
@@ -29,7 +29,7 @@
       </p>
 
       <p class="govuk-body govuk-!-margin-bottom-6">
-        If your organisation does not have someone in one of these roles, email
+        If your organisation does not have someone in one of these roles, email <br />
         <a
           class="govuk-link govuk-link--no-visited-state"
           href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
## What

[PP-15751](https://payments-platform.atlassian.net/browse/PP-15751)

This PR adds the second view in the service director flow, asking for the service directors address. 

- Adds address view 
- Adds get and post controllers to details and address 
- Update paths and routes 
- Unit tests added
- Tiny amendment to details page ensuring email link is all on one line

[PP-15751]: https://payments-platform.atlassian.net/browse/PP-15751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1210" height="895" alt="image" src="https://github.com/user-attachments/assets/acda5037-bcd6-434e-b3e3-df498f6ed1ed" />
