### PR TITLE
PP-15836 add Dependabot exclude cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 0
+  cooldown:
+    exclude:
+      - "@govuk-pay/*"
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
## What

Exclude pay-js-commons from the cooldown period of dependabot updates.

### Accessibility (views have been added/changed)

N/A