### PR TITLE
PP-15751 Add cypress tests for service director skeleton flow

### DIFF
--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
@@ -51,7 +51,8 @@ describe('Controller: settings/adyen-details/service-director/service-director-a
         backLink: formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
           SERVICE_EXTERNAL_ID,
-          SERVICE_TYPE
+          SERVICE_TYPE,
+          GATEWAY_ACCOUNT.getSwitchingCredential().externalId
         ),
       })
     })

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
@@ -4,18 +4,20 @@ import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/fo
 import paths from '@root/paths'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
+  const switchingCredentialId = req.account.getSwitchingCredential().externalId
+
   return response(req, res, 'simplified-account/settings/adyen-details/service-director/address', {
     backLink: formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
       req.service.externalId,
-      req.account.type
+      req.account.type,
+      switchingCredentialId
     ),
   })
 }
 
 function post(req: ServiceRequest, res: ServiceResponse) {
-  const { account } = req
-  const switchingCredentialId = account.getSwitchingCredential().externalId
+  const switchingCredentialId = req.account.getSwitchingCredential().externalId
 
   return res.redirect(
     formatServiceAndAccountPathsFor(

--- a/src/views/simplified-account/settings/adyen-details/service-director/address.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/address.njk
@@ -13,6 +13,10 @@
 
       {% include "simplified-account/settings/partials/_address.njk" %}
     {% endcall %}
-    {{ govukButton({ text: "Continue" }) }}
+    {{
+      govukButton({ id: "service-director-address-submit",
+      text: "Continue",
+      preventDoubleClick: true })
+    }}
   </form>
 {% endblock %}

--- a/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
@@ -15,7 +15,9 @@
           items: [
             {
               href: detailsLink,
-              text: "Change"
+              text: "Change",
+              visuallyHiddenText: "service director's personal details",
+              attributes: { 'data-cy' : 'edit-director-details'}
             }
           ]
         }
@@ -67,7 +69,9 @@
           items: [
             {
               href: addressLink,
-              text: "Change"
+              text: "Change",
+              visuallyHiddenText: "service director's address",
+              attributes: { 'data-cy' : 'edit-director-address'}
             }
           ]
         }

--- a/src/views/simplified-account/settings/adyen-details/service-director/details.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/details.njk
@@ -82,7 +82,7 @@
       {{
         govukInput({
           label: {
-            text: "Email address"
+            text: "Work email address"
           },
           id: "email",
           name: "email",

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
@@ -1,0 +1,185 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const TASK_LIST_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+const SERVICE_DIRECTOR_DETAILS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/details`
+const SERVICE_DIRECTOR_ADDRESS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/address`
+const SERVICE_DIRECTOR_ANSWERS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/check-your-answers`
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe(`Service director - address`, () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+
+    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+    cy.get('h1').should('contain.text', `Service director's address`)
+  })
+
+  describe('for a service that is migrating to adyen', () => {
+    it('should display a back link to service director details', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+
+      cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_DETAILS_PATH)
+    })
+
+    it('should display address line 1, 2, city and postcode inputs', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+
+      cy.get('#address-line1').should('exist')
+      cy.get('#address-line2').should('exist')
+      cy.get('#address-city').should('exist')
+      cy.get('#address-postcode').should('exist')
+    })
+
+    it('should redirect to the service director check your answers page when continue is pressed', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+
+      cy.get('#address-line1').type('7 Green Lane')
+      cy.get('#address-line2').type('Greenfield')
+      cy.get('#address-city').type('Greencity')
+      cy.get('#address-postcode').type('GR3 3NY')
+
+      cy.get('#service-director-address-submit').click()
+
+      cy.location('pathname').should('eq', SERVICE_DIRECTOR_ANSWERS_PATH)
+    })
+  })
+
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+      beforeEach(() => {
+        cy.task('clearStubs')
+
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view service director details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_ADDRESS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
+
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view bank details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_ADDRESS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
@@ -1,0 +1,187 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const TASK_LIST_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+const SERVICE_DIRECTOR_DETAILS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/details`
+const SERVICE_DIRECTOR_ADDRESS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/address`
+const SERVICE_DIRECTOR_ANSWERS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/check-your-answers`
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe(`Service director - check your answers`, () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+    cy.get('h1').should('contain.text', `Check your answers`)
+  })
+
+  describe('for a service that is migrating to adyen', () => {
+    it('should display a back link to service director details', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+      cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_ADDRESS_PATH)
+    })
+
+    it('should redirect to personal details page when change link is clicked in details card', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+      cy.get(`[data-cy='edit-director-details']`).click()
+      cy.location('pathname').should('eq', SERVICE_DIRECTOR_DETAILS_PATH)
+    })
+
+    it('should redirect to address page when change link is clicked in address card', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+      cy.get(`[data-cy='edit-director-address']`).click()
+      cy.location('pathname').should('eq', SERVICE_DIRECTOR_ADDRESS_PATH)
+    })
+
+    it('should redirect to the task list page when continue is pressed', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+      cy.get('#service-director-confirm').click()
+
+      cy.location('pathname').should('eq', TASK_LIST_PATH)
+    })
+  })
+
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+      beforeEach(() => {
+        cy.task('clearStubs')
+
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view service director details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_ANSWERS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
+
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view bank details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_ANSWERS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+  })
+})

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/details.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/details.cy.ts
@@ -1,0 +1,192 @@
+import { UserFixture } from '@test/fixtures/user/user.fixture'
+import { ServiceFixture } from '@test/fixtures/service/service.fixture'
+import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
+import { PaymentProvider } from '@models/constants/payment-provider'
+import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
+import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
+import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+const ADYEN_CREDENTIAL_EXTERNAL_ID = 'adyen-credential-123-abc'
+
+const TASK_LIST_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/switch-psp/switch-to-adyen`
+const SERVICE_DIRECTOR_DETAILS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/details`
+const SERVICE_DIRECTOR_ADDRESS_PATH = `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/service-director/address`
+
+const gatewayAccountFixture = GatewayAccountFixture.forSwitchingPsp(
+  PaymentProvider.STRIPE,
+  PaymentProvider.ADYEN,
+  [],
+  [
+    {
+      externalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+    },
+  ],
+  {
+    id: GATEWAY_ACCOUNT_ID,
+    type: LIVE_ACCOUNT_TYPE,
+    serviceId: SERVICE_EXTERNAL_ID,
+  }
+)
+const serviceFixture = new ServiceFixture({
+  externalId: SERVICE_EXTERNAL_ID,
+  gatewayAccountIds: [`${gatewayAccountFixture.id}`],
+})
+const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+const setStubs = (additionalStubs = []) => {
+  cy.task('setupStubs', [
+    getUser(USER_EXTERNAL_ID).success(userFixture),
+    GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+      gatewayAccountFixture
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe(`Service director - details`, () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+
+  it('accessibility check', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+    cy.a11yCheck()
+  })
+
+  it('should display correct page title and headings', () => {
+    setStubs()
+
+    cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+
+    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+    cy.get('h1').should('contain.text', `Service director details`)
+  })
+
+  describe('for a service that is migrating to adyen', () => {
+    it('should display a back link to the switch-to-adyen task list', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+
+      cy.get('.govuk-back-link').should('have.attr', 'href', TASK_LIST_PATH)
+    })
+
+    it('should display first name, last name, date of birth and work email address inputs', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+
+      cy.get('#first-name').should('exist')
+      cy.get('#last-name').should('exist')
+
+      cy.get('#dob-day').should('exist')
+      cy.get('#dob-month').should('exist')
+      cy.get('#dob-year').should('exist')
+
+      cy.get('#email').should('exist')
+    })
+
+    it('should redirect to the service director address page when continue is pressed', () => {
+      setStubs()
+
+      cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+
+      cy.get('#first-name').type('John')
+      cy.get('#last-name').type('McClane')
+
+      cy.get('#dob-day').type('25')
+      cy.get('#dob-month').type('12')
+      cy.get('#dob-year').type('1960')
+
+      cy.get('#email').type('yippeekiyay@example.gov.uk')
+
+      cy.get('#service-director-details-submit').click()
+
+      cy.location('pathname').should('eq', SERVICE_DIRECTOR_ADDRESS_PATH)
+    })
+  })
+
+  describe('for a service not migrating to Adyen', () => {
+    describe('where the service is switching to a different PSP', () => {
+      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+      beforeEach(() => {
+        cy.task('clearStubs')
+
+        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+          PaymentProvider.STRIPE,
+          PaymentProvider.WORLDPAY,
+          [],
+          [
+            {
+              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+            },
+          ],
+          {
+            id: GATEWAY_ACCOUNT_ID,
+            serviceId: SERVICE_EXTERNAL_ID,
+          }
+        )
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            gatewayAccountSwitchingToWorldpay
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view service director details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_DETAILS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+
+    describe('where the service is not switching PSP', () => {
+      beforeEach(() => {
+        cy.task('clearStubs')
+        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+          type: LIVE_ACCOUNT_TYPE,
+        })
+
+        const serviceFixture = new ServiceFixture({
+          externalId: SERVICE_EXTERNAL_ID,
+          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+          currentGoLiveStage: 'LIVE',
+        })
+        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+        cy.task('setupStubs', [
+          getUser(USER_EXTERNAL_ID).success(userFixture),
+          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+            adyenGatewayAccount
+          ),
+        ])
+      })
+
+      it('should return a 404 when attempting to view bank details', () => {
+        cy.request({
+          url: SERVICE_DIRECTOR_DETAILS_PATH,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What

[PP-15751](https://payments-platform.atlassian.net/browse/PP-15751)

- Amends email address to 'work email address' on details page as per updated design.
- Amend back link in address controller to accept credentialID to fix path.
- Adds cypress test for each of three pages in service director flow. 

**For now, as these are skeleton views, the check your answers page has hardcoded values which I have not tested against.** 

**The back links currently all have the functionality of going back to the previous page in the flow (so for example if you are in the address view and click back, you will always go to the details view) - in future this will be updated to work with the change buttons in the check your answers view. So if you had come from the check your answers view through the change links, pressing back in the address view takes you back to the check your answers view rather than to details. This has not been implemented yet as per this PR so has not been tested.**


[PP-15751]: https://payments-platform.atlassian.net/browse/PP-15751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ