### PR TITLE
PP-15751 Add persistence to answers and back link flow

### DIFF
--- a/src/controllers/simplified-account/settings/adyen-details/service-director/constants.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/constants.ts
@@ -1,0 +1,39 @@
+import { ServiceRequest } from '@utils/types/express'
+import lodash from 'lodash'
+
+const CREATE_SESSION_KEY = 'session.pageData.serviceDirector'
+
+export class ServiceDirectorSession {
+  firstName?: string
+  lastName?: string
+  dobDay?: string
+  dobMonth?: string
+  dobYear?: string
+  email?: string
+  addressLine1?: string
+  addressLine2?: string
+  addressCity?: string
+  addressPostcode?: string
+
+  constructor(data: ServiceDirectorSession) {
+    Object.assign(this, data)
+  }
+
+  static extract(req: ServiceRequest<unknown>) {
+    return new ServiceDirectorSession(lodash.get(req, CREATE_SESSION_KEY, {} as ServiceDirectorSession))
+  }
+
+  static set(req: ServiceRequest<unknown>, ...sessionData: ServiceDirectorSession[]) {
+    lodash.set(req, CREATE_SESSION_KEY, Object.assign({}, ...sessionData))
+  }
+
+  static clear(req: ServiceRequest<unknown>) {
+    return lodash.unset(req, CREATE_SESSION_KEY)
+  }
+
+  isEmpty() {
+    return lodash.isEmpty(lodash.omitBy(this, (v) => lodash.isUndefined(v)))
+  }
+}
+
+export const FROM_REVIEW_QUERY_PARAM = 'fromReview'

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
@@ -148,7 +148,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-a
       nextRequest({
         session: {
           pageData: {
-            responsiblePerson: {},
+            serviceDirector: {},
           },
         },
         body: {

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
@@ -6,6 +6,7 @@ import { ServiceFixture } from '@test/fixtures/service/service.fixture'
 import sinon from 'sinon'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { FROM_REVIEW_QUERY_PARAM, ServiceDirectorSession } from './constants'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const SERVICE_TYPE = 'live'
@@ -18,7 +19,7 @@ const GATEWAY_ACCOUNT = GatewayAccountFixture.forSwitchingPsp(PaymentProvider.ST
 
 const mockResponse = sinon.stub()
 
-const { req, res, call } = new ControllerTestBuilder(
+const { nextRequest, res, call } = new ControllerTestBuilder(
   '@controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller'
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
@@ -31,35 +32,135 @@ const { req, res, call } = new ControllerTestBuilder(
 
 describe('Controller: settings/adyen-details/service-director/service-director-address', () => {
   describe('get', () => {
-    it('should call the response function with req, res, and the template path', async () => {
-      await call('get')
+    describe('with empty session data', () => {
+      beforeEach(async () => {
+        nextRequest({
+          session: {},
+        })
 
-      mockResponse.should.have.been.calledOnce
-      mockResponse.should.have.been.calledWith(
-        req,
-        res,
-        'simplified-account/settings/adyen-details/service-director/address'
-      )
+        await call('get')
+      })
+      it('should redirect to the Adyen migration task list', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/switch-to-adyen/))
+      })
     })
 
-    it('should call the response method with the backLink', async () => {
-      await call('get')
+    describe('with valid session data', () => {
+      beforeEach(async () => {
+        const currentSession: Partial<ServiceDirectorSession> = {
+          firstName: 'Sam',
+          lastName: 'Person',
+          dobDay: '25',
+          dobMonth: '12',
+          dobYear: '1970',
+          email: 'sam.person@gov.example.com',
+          addressLine1: '29 Acacia Road',
+          addressCity: 'London',
+          addressPostcode: 'W1 2AB',
+        }
 
-      mockResponse.should.have.been.calledOnce
-      const context = mockResponse.firstCall.lastArg as { backLink: string }
-      sinon.assert.match(context, {
-        backLink: formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
-          SERVICE_EXTERNAL_ID,
-          SERVICE_TYPE,
-          GATEWAY_ACCOUNT.getSwitchingCredential().externalId
-        ),
+        nextRequest({
+          session: {
+            pageData: {
+              serviceDirector: currentSession,
+            },
+          },
+        })
+
+        await call('get')
+      })
+      it('should call the response function with the template path', async () => {
+        mockResponse.should.have.been.calledOnce
+        mockResponse.should.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/adyen-details/service-director/address'
+        )
+      })
+
+      it('should set form values from session in context', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+        const addressValues = context.address as Record<string, unknown>
+        sinon.assert.match(addressValues.addressLine1, '29 Acacia Road')
+        sinon.assert.match(addressValues.addressCity, 'London')
+        sinon.assert.match(addressValues.addressPostcode, 'W1 2AB')
+      })
+
+      it('should call the response method with the backLink set to details page', async () => {
+        mockResponse.should.have.been.calledOnce
+        const context = mockResponse.firstCall.lastArg as { backLink: string }
+        sinon.assert.match(context, {
+          backLink: formatServiceAndAccountPathsFor(
+            paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+            SERVICE_EXTERNAL_ID,
+            SERVICE_TYPE,
+            GATEWAY_ACCOUNT.getSwitchingCredential().externalId
+          ),
+        })
+      })
+    })
+
+    describe('when user is coming from check your answers page', () => {
+      beforeEach(async () => {
+        const currentSession: Partial<ServiceDirectorSession> = {
+          firstName: 'Sam',
+          lastName: 'Person',
+          dobDay: '25',
+          dobMonth: '12',
+          dobYear: '1970',
+          email: 'sam.person@gov.example.com',
+          addressLine1: '29 Acacia Road',
+          addressCity: 'London',
+          addressPostcode: 'W1 2AB',
+        }
+
+        nextRequest({
+          query: { [FROM_REVIEW_QUERY_PARAM]: 'true' },
+          session: {
+            pageData: {
+              serviceDirector: currentSession,
+            },
+          },
+        })
+
+        await call('get')
+      })
+
+      it('should call the response method with the backLink set to the check your answers page', () => {
+        mockResponse.should.have.been.calledOnce
+        const context = mockResponse.firstCall.lastArg as { backLink: string }
+        sinon.assert.match(context, {
+          backLink: formatServiceAndAccountPathsFor(
+            paths.simplifiedAccount.settings.adyenDetails.serviceDirector.checkYourAnswers,
+            SERVICE_EXTERNAL_ID,
+            SERVICE_TYPE,
+            GATEWAY_ACCOUNT.getSwitchingCredential().externalId
+          ),
+        })
       })
     })
   })
   describe('post', () => {
-    it('should redirect to service director check your answers', async () => {
+    beforeEach(async () => {
+      res.redirect.resetHistory()
+
+      nextRequest({
+        session: {
+          pageData: {
+            responsiblePerson: {},
+          },
+        },
+        body: {
+          addressLine1: '29 Acacia Road',
+          addressCity: 'London',
+          addressPostcode: 'W1 2AB',
+        },
+      })
+
       await call('post')
+    })
+    it('should redirect to service director check your answers page', async () => {
       sinon.assert.calledOnceWithExactly(
         res.redirect,
         formatServiceAndAccountPathsFor(

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.test.ts
@@ -70,7 +70,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-a
 
         await call('get')
       })
-      it('should call the response function with the template path', async () => {
+      it('should call the response function with the template path', () => {
         mockResponse.should.have.been.calledOnce
         mockResponse.should.have.been.calledWith(
           sinon.match.any,
@@ -87,7 +87,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-a
         sinon.assert.match(addressValues.addressPostcode, 'W1 2AB')
       })
 
-      it('should call the response method with the backLink set to details page', async () => {
+      it('should call the response method with the backLink set to details page', () => {
         mockResponse.should.have.been.calledOnce
         const context = mockResponse.firstCall.lastArg as { backLink: string }
         sinon.assert.match(context, {
@@ -160,7 +160,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-a
 
       await call('post')
     })
-    it('should redirect to service director check your answers page', async () => {
+    it('should redirect to service director check your answers page', () => {
       sinon.assert.calledOnceWithExactly(
         res.redirect,
         formatServiceAndAccountPathsFor(

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-address.controller.ts
@@ -2,22 +2,70 @@ import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { FROM_REVIEW_QUERY_PARAM, ServiceDirectorSession } from './constants'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
-  const switchingCredentialId = req.account.getSwitchingCredential().externalId
+  const { account } = req
+  const switchingCredentialId = account.getSwitchingCredential().externalId
+  const currentSession = ServiceDirectorSession.extract(req)
+
+  if (currentSession.isEmpty()) {
+    return res.redirect(
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+        req.service.externalId,
+        req.account.type
+      )
+    )
+  }
+
+  const address = {
+    addressLine1: currentSession.addressLine1 ?? '',
+    addressLine2: currentSession.addressLine2 ?? '',
+    addressCity: currentSession.addressCity ?? '',
+    addressPostcode: currentSession.addressPostcode ?? '',
+  }
+
+  const detailsLink = formatServiceAndAccountPathsFor(
+    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+    req.service.externalId,
+    req.account.type,
+    switchingCredentialId
+  )
+
+  const reviewLink = formatServiceAndAccountPathsFor(
+    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.checkYourAnswers,
+    req.service.externalId,
+    req.account.type,
+    switchingCredentialId
+  )
+
+  const backLink = req.query[FROM_REVIEW_QUERY_PARAM] === 'true' ? reviewLink : detailsLink
 
   return response(req, res, 'simplified-account/settings/adyen-details/service-director/address', {
-    backLink: formatServiceAndAccountPathsFor(
-      paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
-      req.service.externalId,
-      req.account.type,
-      switchingCredentialId
-    ),
+    backLink,
+    address,
   })
 }
 
-function post(req: ServiceRequest, res: ServiceResponse) {
-  const switchingCredentialId = req.account.getSwitchingCredential().externalId
+interface ServiceDirectorAddressBody {
+  addressLine1: string
+  addressLine2: string
+  addressCity: string
+  addressPostcode: string
+}
+
+function post(req: ServiceRequest<ServiceDirectorAddressBody>, res: ServiceResponse) {
+  const { account } = req
+  const switchingCredentialId = account.getSwitchingCredential().externalId
+  const currentSession = ServiceDirectorSession.extract(req)
+
+  ServiceDirectorSession.set(req, currentSession, {
+    addressLine1: req.body.addressLine1,
+    addressLine2: req.body.addressLine2,
+    addressCity: req.body.addressCity,
+    addressPostcode: req.body.addressPostcode,
+  } as ServiceDirectorSession)
 
   return res.redirect(
     formatServiceAndAccountPathsFor(

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.test.ts
@@ -6,6 +6,8 @@ import { ServiceFixture } from '@test/fixtures/service/service.fixture'
 import sinon from 'sinon'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { ServiceDirectorSession } from './constants'
+import Service from '@models/service/Service.class'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const SERVICE_TYPE = 'live'
@@ -18,7 +20,7 @@ const GATEWAY_ACCOUNT = GatewayAccountFixture.forSwitchingPsp(PaymentProvider.ST
 
 const mockResponse = sinon.stub()
 
-const { req, res, call } = new ControllerTestBuilder(
+const { nextRequest, res, call } = new ControllerTestBuilder(
   '@controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller'
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
@@ -31,34 +33,96 @@ const { req, res, call } = new ControllerTestBuilder(
 
 describe('Controller: settings/adyen-details/service-director/service-director-check-your-answers', () => {
   describe('get', () => {
-    it('should call the response function with req, res, and the template path', async () => {
-      await call('get')
+    describe('with empty session data', () => {
+      beforeEach(async () => {
+        nextRequest({
+          session: {},
+        })
 
-      mockResponse.should.have.been.calledOnce
-      mockResponse.should.have.been.calledWith(
-        req,
-        res,
-        'simplified-account/settings/adyen-details/service-director/check-your-answers'
-      )
+        await call('get')
+      })
+      it('should redirect to the Adyen migration task list', () => {
+        sinon.assert.calledOnce(res.redirect)
+        sinon.assert.calledWith(res.redirect, sinon.match(/switch-to-adyen/))
+      })
     })
 
-    it('should call the response method with the backLink', async () => {
-      await call('get')
+    describe('with valid session data', () => {
+      beforeEach(async () => {
+        const currentSession: Partial<ServiceDirectorSession> = {
+          firstName: 'Sam',
+          lastName: 'Person',
+          dobDay: '25',
+          dobMonth: '12',
+          dobYear: '1970',
+          email: 'sam.person@gov.example.com',
+          addressLine1: '29 Acacia Road',
+          addressCity: 'London',
+          addressPostcode: 'W1 2AB',
+        }
 
-      mockResponse.should.have.been.calledOnce
-      const context = mockResponse.firstCall.lastArg as { backLink: string }
-      sinon.assert.match(context, {
-        backLink: formatServiceAndAccountPathsFor(
+        nextRequest({
+          session: {
+            pageData: {
+              serviceDirector: currentSession,
+            },
+          },
+        })
+
+        await call('get')
+      })
+
+      it('should call the response function with req, res, and the template path', async () => {
+        mockResponse.should.have.been.calledOnce
+        mockResponse.should.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/adyen-details/service-director/check-your-answers'
+        )
+      })
+
+      it('should set review values from session in context', () => {
+        const context = mockResponse.args[0][3] as Record<string, unknown>
+        const submittedAnswers = context.currentSession as Record<string, unknown>
+        sinon.assert.match(submittedAnswers.firstName, 'Sam')
+        sinon.assert.match(submittedAnswers.lastName, 'Person')
+        sinon.assert.match(submittedAnswers.dobDay, '25')
+        sinon.assert.match(submittedAnswers.dobMonth, '12')
+        sinon.assert.match(submittedAnswers.dobYear, '1970')
+        sinon.assert.match(submittedAnswers.email, 'sam.person@gov.example.com')
+        sinon.assert.match(submittedAnswers.addressLine1, '29 Acacia Road')
+        sinon.assert.match(submittedAnswers.addressCity, 'London')
+        sinon.assert.match(submittedAnswers.addressPostcode, 'W1 2AB')
+      })
+
+      it('should call the response method with the back and change links', async () => {
+        mockResponse.should.have.been.calledOnce
+        const context = mockResponse.firstCall.lastArg as { backLink: string }
+        const fromReviewParam = '?fromReview=true'
+        const addressLink = formatServiceAndAccountPathsFor(
           paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
           SERVICE_EXTERNAL_ID,
           SERVICE_TYPE,
           GATEWAY_ACCOUNT.getSwitchingCredential().externalId
-        ),
+        )
+
+        sinon.assert.match(context, {
+          backLink: addressLink + fromReviewParam,
+          addressLink: addressLink + fromReviewParam,
+          detailsLink:
+            formatServiceAndAccountPathsFor(
+              paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+              SERVICE_EXTERNAL_ID,
+              SERVICE_TYPE,
+              GATEWAY_ACCOUNT.getSwitchingCredential().externalId
+            ) + fromReviewParam,
+        })
       })
     })
   })
+
   describe('post', () => {
-    it('should redirect to service director check your answers', async () => {
+    it('should redirect to Adyen migration task list', async () => {
       await call('post')
       sinon.assert.calledOnceWithExactly(
         res.redirect,

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.test.ts
@@ -7,7 +7,6 @@ import sinon from 'sinon'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
 import { ServiceDirectorSession } from './constants'
-import Service from '@models/service/Service.class'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const SERVICE_TYPE = 'live'
@@ -72,7 +71,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-c
         await call('get')
       })
 
-      it('should call the response function with req, res, and the template path', async () => {
+      it('should call the response function the template path', () => {
         mockResponse.should.have.been.calledOnce
         mockResponse.should.have.been.calledWith(
           sinon.match.any,
@@ -95,7 +94,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-c
         sinon.assert.match(submittedAnswers.addressPostcode, 'W1 2AB')
       })
 
-      it('should call the response method with the back and change links', async () => {
+      it('should call the response method with the back and change links', () => {
         mockResponse.should.have.been.calledOnce
         const context = mockResponse.firstCall.lastArg as { backLink: string }
         const fromReviewParam = '?fromReview=true'

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-check-your-answers.controller.ts
@@ -2,43 +2,57 @@ import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { FROM_REVIEW_QUERY_PARAM, ServiceDirectorSession } from './constants'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
   const { account } = req
   const switchingCredentialId = account.getSwitchingCredential().externalId
+  const currentSession = ServiceDirectorSession.extract(req)
+
+  if (currentSession.isEmpty()) {
+    return res.redirect(
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+        req.service.externalId,
+        req.account.type
+      )
+    )
+  }
+
+  const fromReviewQueryString = FROM_REVIEW_QUERY_PARAM + '=true'
 
   const detailsLink = formatServiceAndAccountPathsFor(
-    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details,
+    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.details + '?' + fromReviewQueryString,
     req.service.externalId,
     req.account.type,
     switchingCredentialId
   )
 
   const addressLink = formatServiceAndAccountPathsFor(
-    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
+    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address + '?' + fromReviewQueryString,
     req.service.externalId,
     req.account.type,
     switchingCredentialId
   )
 
+  const dateOfBirth = `${currentSession.dobYear}-${currentSession.dobMonth}-${currentSession.dobDay}`
+
   return response(req, res, 'simplified-account/settings/adyen-details/service-director/check-your-answers', {
-    hasAddressLine2: true,
+    hasAddressLine2: currentSession.addressLine2?.length,
     detailsLink,
     addressLink,
     backLink: addressLink,
+    currentSession,
+    dateOfBirth,
   })
 }
 
 function post(req: ServiceRequest, res: ServiceResponse) {
-  const { account } = req
-  const switchingCredentialId = account.getSwitchingCredential().externalId
-
   return res.redirect(
     formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
       req.service.externalId,
-      req.account.type,
-      switchingCredentialId
+      req.account.type
     )
   )
 }

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
@@ -81,7 +81,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
         nextRequest({
           session: {
             pageData: {
-              responsiblePerson: {},
+              serviceDirector: {},
             },
           },
           body: {

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
@@ -6,6 +6,7 @@ import { ServiceFixture } from '@test/fixtures/service/service.fixture'
 import sinon from 'sinon'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { ServiceDirectorSession } from './constants'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const SERVICE_TYPE = 'live'
@@ -18,7 +19,7 @@ const GATEWAY_ACCOUNT = GatewayAccountFixture.forSwitchingPsp(PaymentProvider.ST
 
 const mockResponse = sinon.stub()
 
-const { req, res, call } = new ControllerTestBuilder(
+const { nextRequest, res, call } = new ControllerTestBuilder(
   '@controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller'
 )
   .withServiceExternalId(SERVICE_EXTERNAL_ID)
@@ -31,43 +32,82 @@ const { req, res, call } = new ControllerTestBuilder(
 
 describe('Controller: settings/adyen-details/service-director/service-director-details', () => {
   describe('get', () => {
-    it('should call the response function with req, res, and the template path', async () => {
-      await call('get')
+    describe('with valid session data', () => {
+      beforeEach(async () => {
+        const currentSession: Partial<ServiceDirectorSession> = {
+          firstName: 'Sam',
+          lastName: 'Person',
+          dobDay: '25',
+          dobMonth: '12',
+          dobYear: '1970',
+          email: 'sam.person@gov.example.com',
+        }
 
-      mockResponse.should.have.been.calledOnce
-      mockResponse.should.have.been.calledWith(
-        req,
-        res,
-        'simplified-account/settings/adyen-details/service-director/details'
-      )
-    })
+        nextRequest({
+          session: {
+            pageData: {
+              serviceDirector: currentSession,
+            },
+          },
+        })
 
-    it('should call the response method with the backLink', async () => {
-      await call('get')
+        await call('get')
+      })
+      it('should call the response function with the template path', async () => {
+        mockResponse.should.have.been.calledOnce
+        mockResponse.should.have.been.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          'simplified-account/settings/adyen-details/service-director/details'
+        )
+      })
 
-      mockResponse.should.have.been.calledOnce
-      const context = mockResponse.firstCall.lastArg as { backLink: string }
-      sinon.assert.match(context, {
-        backLink: formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
-          SERVICE_EXTERNAL_ID,
-          SERVICE_TYPE
-        ),
+      it('should call the response method with the backLink', async () => {
+        mockResponse.should.have.been.calledOnce
+        const context = mockResponse.firstCall.lastArg as { backLink: string }
+        sinon.assert.match(context, {
+          backLink: formatServiceAndAccountPathsFor(
+            paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+            SERVICE_EXTERNAL_ID,
+            SERVICE_TYPE
+          ),
+        })
       })
     })
-  })
-  describe('post', () => {
-    it('should redirect to the service director address', async () => {
-      await call('post')
-      sinon.assert.calledOnceWithExactly(
-        res.redirect,
-        formatServiceAndAccountPathsFor(
-          paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
-          SERVICE_EXTERNAL_ID,
-          SERVICE_TYPE,
-          GATEWAY_ACCOUNT.getSwitchingCredential().externalId
+    describe('post', () => {
+      beforeEach(async () => {
+        res.redirect.resetHistory()
+
+        nextRequest({
+          session: {
+            pageData: {
+              responsiblePerson: {},
+            },
+          },
+          body: {
+            firstName: 'Sam',
+            lastName: 'Person',
+            dobDay: '25',
+            dobMonth: '12',
+            dobYear: '1970',
+            email: 'sam.person@gov.example.com',
+          },
+        })
+
+        await call('post')
+      })
+
+      it('should redirect to the service director address', async () => {
+        sinon.assert.calledOnceWithExactly(
+          res.redirect,
+          formatServiceAndAccountPathsFor(
+            paths.simplifiedAccount.settings.adyenDetails.serviceDirector.address,
+            SERVICE_EXTERNAL_ID,
+            SERVICE_TYPE,
+            GATEWAY_ACCOUNT.getSwitchingCredential().externalId
+          )
         )
-      )
+      })
     })
   })
 })

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.test.ts
@@ -53,7 +53,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
 
         await call('get')
       })
-      it('should call the response function with the template path', async () => {
+      it('should call the response function with the template path', () => {
         mockResponse.should.have.been.calledOnce
         mockResponse.should.have.been.calledWith(
           sinon.match.any,
@@ -62,7 +62,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
         )
       })
 
-      it('should call the response method with the backLink', async () => {
+      it('should call the response method with the backLink', () => {
         mockResponse.should.have.been.calledOnce
         const context = mockResponse.firstCall.lastArg as { backLink: string }
         sinon.assert.match(context, {
@@ -97,7 +97,7 @@ describe('Controller: settings/adyen-details/service-director/service-director-d
         await call('post')
       })
 
-      it('should redirect to the service director address', async () => {
+      it('should redirect to the service director address', () => {
         sinon.assert.calledOnceWithExactly(
           res.redirect,
           formatServiceAndAccountPathsFor(

--- a/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
+++ b/src/controllers/simplified-account/settings/adyen-details/service-director/service-director-details.controller.ts
@@ -2,20 +2,73 @@ import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
+import { FROM_REVIEW_QUERY_PARAM, ServiceDirectorSession } from './constants'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
+  const currentSession = ServiceDirectorSession.extract(req)
+  const { account } = req
+  const switchingCredentialId = account.getSwitchingCredential().externalId
+
+  const name = {
+    firstName: currentSession.firstName ?? '',
+    lastName: currentSession.lastName ?? '',
+  }
+
+  const dob = {
+    dobDay: currentSession.dobDay ?? '',
+    dobMonth: currentSession.dobMonth ?? '',
+    dobYear: currentSession.dobYear ?? '',
+  }
+
+  const email = {
+    email: currentSession.email ?? '',
+  }
+
+  const switchToAdyenLink = formatServiceAndAccountPathsFor(
+    paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
+    req.service.externalId,
+    req.account.type
+  )
+
+  const reviewLink = formatServiceAndAccountPathsFor(
+    paths.simplifiedAccount.settings.adyenDetails.serviceDirector.checkYourAnswers,
+    req.service.externalId,
+    req.account.type,
+    switchingCredentialId
+  )
+
+  const backLink = req.query[FROM_REVIEW_QUERY_PARAM] === 'true' ? reviewLink : switchToAdyenLink
+
   return response(req, res, 'simplified-account/settings/adyen-details/service-director/details', {
-    backLink: formatServiceAndAccountPathsFor(
-      paths.simplifiedAccount.settings.switchPsp.switchToAdyen.index,
-      req.service.externalId,
-      req.account.type
-    ),
+    backLink,
+    name,
+    dob,
+    email,
   })
 }
 
-function post(req: ServiceRequest, res: ServiceResponse) {
+interface ServiceDirectorDetailsBody {
+  firstName: string
+  lastName: string
+  dobDay: string
+  dobMonth: string
+  dobYear: string
+  email: string
+}
+
+function post(req: ServiceRequest<ServiceDirectorDetailsBody>, res: ServiceResponse) {
   const { account } = req
   const switchingCredentialId = account.getSwitchingCredential().externalId
+  const currentSession = ServiceDirectorSession.extract(req)
+
+  ServiceDirectorSession.set(req, currentSession, {
+    firstName: req.body.firstName,
+    lastName: req.body.lastName,
+    dobDay: req.body.dobDay,
+    dobMonth: req.body.dobMonth,
+    dobYear: req.body.dobYear,
+    email: req.body.email,
+  } as ServiceDirectorSession)
 
   return res.redirect(
     formatServiceAndAccountPathsFor(

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
@@ -2,10 +2,12 @@ import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import { AdyenTasks } from '@models/task-workflows/AdyenTasks.class'
 import { ResponsiblePersonSession } from '../../adyen-details/responsible-person/constants'
+import { ServiceDirectorSession } from '../../adyen-details/service-director/constants'
 
 function get(req: ServiceRequest, res: ServiceResponse) {
   const adyenTasks = AdyenTasks.forProviderSwitching(req.service, req.account)
   ResponsiblePersonSession.clear(req)
+  ServiceDirectorSession.clear(req)
 
   return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/index.njk', {
     currentPsp: req.account.paymentProvider,

--- a/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
@@ -28,10 +28,7 @@
             text: "First name"
           },
           value: {
-            html: currentSession.firstName,
-            attributes: {
-            data-cy: "first-name-row"
-          }
+            html: currentSession.firstName
           }
         },
         {
@@ -39,10 +36,7 @@
             text: "Last name"
           },
           value: {
-            html: currentSession.lastName,
-            attributes: {
-            data-cy: "last-name-row"
-          }
+            html: currentSession.lastName
           }
         },
         {
@@ -50,23 +44,16 @@
             text: "Date of birth"
           },
           value: {
-            html: dateOfBirth | govukDate,
-            attributes: {
-            data-cy: "dob-row"
-          },
-          },
+            html: dateOfBirth | govukDate
           }
+        },
         {
           key: {
             text: "Work email address"
           },
           value: {
-            html: currentSession.email,
-            attributes: {
-            data-cy: "email-row"
+            html: currentSession.email
           }
-          }
-
         }
       ]
     })
@@ -95,10 +82,7 @@
             text: "Address line 1"
           },
           value: {
-            html: currentSession.addressLine1,
-            attributes: {
-            data-cy: "address-1-row"
-          }
+            html: currentSession.addressLine1
           }
         },
         {
@@ -106,10 +90,7 @@
             text: "Address line 2"
           },
           value: {
-            html: currentSession.addressLine2,
-            attributes: {
-            data-cy: "address-2-row"
-          }
+            html: currentSession.addressLine2
           }
         } if hasAddressLine2,
         {
@@ -117,10 +98,7 @@
             text: "Town or city"
           },
           value: {
-            html: currentSession.addressCity,
-            attributes: {
-            data-cy: "town-city-row"
-          }
+            html: currentSession.addressCity
           }
         },
         {
@@ -128,11 +106,8 @@
             text: "Postcode"
           },
           value: {
-            html: currentSession.addressPostcode,
-            attributes: {
-            data-cy: "postcode-row"
+            html: currentSession.addressPostcode
           }
-          },
         }
       ]
     })

--- a/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
+++ b/src/views/simplified-account/settings/adyen-details/service-director/check-your-answers.njk
@@ -28,7 +28,10 @@
             text: "First name"
           },
           value: {
-            html: "Sam"
+            html: currentSession.firstName,
+            attributes: {
+            data-cy: "first-name-row"
+          }
           }
         },
         {
@@ -36,7 +39,10 @@
             text: "Last name"
           },
           value: {
-            html: "Person"
+            html: currentSession.lastName,
+            attributes: {
+            data-cy: "last-name-row"
+          }
           }
         },
         {
@@ -44,16 +50,23 @@
             text: "Date of birth"
           },
           value: {
-            html: "01 January 1970"
+            html: dateOfBirth | govukDate,
+            attributes: {
+            data-cy: "dob-row"
+          },
+          },
           }
-        },
         {
           key: {
             text: "Work email address"
           },
           value: {
-            html: "S.person@example.gov.uk"
+            html: currentSession.email,
+            attributes: {
+            data-cy: "email-row"
           }
+          }
+
         }
       ]
     })
@@ -82,7 +95,10 @@
             text: "Address line 1"
           },
           value: {
-            html: "29 Acacia Road"
+            html: currentSession.addressLine1,
+            attributes: {
+            data-cy: "address-1-row"
+          }
           }
         },
         {
@@ -90,7 +106,10 @@
             text: "Address line 2"
           },
           value: {
-            html: "Mitcham"
+            html: currentSession.addressLine2,
+            attributes: {
+            data-cy: "address-2-row"
+          }
           }
         } if hasAddressLine2,
         {
@@ -98,7 +117,10 @@
             text: "Town or city"
           },
           value: {
-            html: "London"
+            html: currentSession.addressCity,
+            attributes: {
+            data-cy: "town-city-row"
+          }
           }
         },
         {
@@ -106,8 +128,11 @@
             text: "Postcode"
           },
           value: {
-            html: "SW16 1AB"
+            html: currentSession.addressPostcode,
+            attributes: {
+            data-cy: "postcode-row"
           }
+          },
         }
       ]
     })

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
@@ -53,131 +53,145 @@ describe(`Service director - address`, () => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
   })
 
-  it('accessibility check', () => {
-    setStubs()
-
-    cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
-    cy.a11yCheck()
-  })
-
-  it('should display correct page title and headings', () => {
-    setStubs()
-
-    cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
-
-    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
-    cy.get('h1').should('contain.text', `Service director's address`)
-  })
-
   describe('for a service that is migrating to adyen', () => {
-    it('should display a back link to service director details', () => {
-      setStubs()
-
-      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
-
-      cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_DETAILS_PATH)
-    })
-
-    it('should display address line 1, 2, city and postcode inputs', () => {
-      setStubs()
-
-      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
-
-      cy.get('#address-line1').should('exist')
-      cy.get('#address-line2').should('exist')
-      cy.get('#address-city').should('exist')
-      cy.get('#address-postcode').should('exist')
-    })
-
-    it('should redirect to the service director check your answers page when continue is pressed', () => {
-      setStubs()
-
-      cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
-
-      cy.get('#address-line1').type('7 Green Lane')
-      cy.get('#address-line2').type('Greenfield')
-      cy.get('#address-city').type('Greencity')
-      cy.get('#address-postcode').type('GR3 3NY')
-
-      cy.get('#service-director-address-submit').click()
-
-      cy.location('pathname').should('eq', SERVICE_DIRECTOR_ANSWERS_PATH)
-    })
-  })
-
-  describe('for a service not migrating to Adyen', () => {
-    describe('where the service is switching to a different PSP', () => {
-      const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
-
+    describe('when navigating to the page directly', () => {
       beforeEach(() => {
-        cy.task('clearStubs')
+        setStubs()
+      })
 
-        const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
-          PaymentProvider.STRIPE,
-          PaymentProvider.WORLDPAY,
-          [],
-          [
+      it('should redirect to the migration tasks page', () => {
+        setStubs()
+
+        cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+
+        cy.location('pathname').should('eq', TASK_LIST_PATH)
+      })
+    })
+
+    describe('when navigating from the details page with fields populated', () => {
+      beforeEach(() => {
+        setStubs()
+        cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+        cy.get('#first-name').type('John')
+        cy.get('#last-name').type('McClane')
+
+        cy.get('#dob-day').type('25')
+        cy.get('#dob-month').type('12')
+        cy.get('#dob-year').type('1960')
+
+        cy.get('#email').type('yippeekiyay@example.gov.uk')
+
+        cy.get('#service-director-details-submit').click()
+      })
+
+      it('accessibility check', () => {
+        setStubs()
+
+        cy.visit(SERVICE_DIRECTOR_ADDRESS_PATH)
+        cy.a11yCheck()
+      })
+
+      it('should display correct page content', () => {
+        setStubs()
+
+        checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+        cy.get('h1').should('contain.text', `Service director's address`)
+        cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_DETAILS_PATH)
+
+        cy.get('#address-line1').should('exist')
+        cy.get('#address-line2').should('exist')
+        cy.get('#address-city').should('exist')
+        cy.get('#address-postcode').should('exist')
+      })
+
+      it('should redirect to the service director check your answers page when continue is pressed', () => {
+        setStubs()
+
+        cy.get('#address-line1').type('7 Green Lane')
+        cy.get('#address-line2').type('Greenfield')
+        cy.get('#address-city').type('Greencity')
+        cy.get('#address-postcode').type('GR3 3NY')
+
+        cy.get('#service-director-address-submit').click()
+
+        cy.location('pathname').should('eq', SERVICE_DIRECTOR_ANSWERS_PATH)
+      })
+    })
+
+    describe('for a service not migrating to Adyen', () => {
+      describe('where the service is switching to a different PSP', () => {
+        const WORLDPAY_CREDENTIAL_EXTERNAL_ID = 'worldpay-credential-123-abc'
+
+        beforeEach(() => {
+          cy.task('clearStubs')
+
+          const gatewayAccountSwitchingToWorldpay = GatewayAccountFixture.forSwitchingPsp(
+            PaymentProvider.STRIPE,
+            PaymentProvider.WORLDPAY,
+            [],
+            [
+              {
+                externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
+              },
+            ],
             {
-              externalId: WORLDPAY_CREDENTIAL_EXTERNAL_ID,
-            },
-          ],
-          {
-            id: GATEWAY_ACCOUNT_ID,
-            serviceId: SERVICE_EXTERNAL_ID,
-          }
-        )
-        const serviceFixture = new ServiceFixture({
-          externalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
-          currentGoLiveStage: 'LIVE',
+              id: GATEWAY_ACCOUNT_ID,
+              serviceId: SERVICE_EXTERNAL_ID,
+            }
+          )
+          const serviceFixture = new ServiceFixture({
+            externalId: SERVICE_EXTERNAL_ID,
+            gatewayAccountIds: [`${gatewayAccountSwitchingToWorldpay.id}`],
+            currentGoLiveStage: 'LIVE',
+          })
+          const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+          cy.task('setupStubs', [
+            getUser(USER_EXTERNAL_ID).success(userFixture),
+            GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+              gatewayAccountSwitchingToWorldpay
+            ),
+          ])
         })
-        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
-        cy.task('setupStubs', [
-          getUser(USER_EXTERNAL_ID).success(userFixture),
-          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
-            gatewayAccountSwitchingToWorldpay
-          ),
-        ])
-      })
 
-      it('should return a 404 when attempting to view service director details', () => {
-        cy.request({
-          url: SERVICE_DIRECTOR_ADDRESS_PATH,
-          failOnStatusCode: false,
-        }).then((response) => {
-          expect(response.status).to.eq(404)
+        it('should return a 404 when attempting to view address page', () => {
+          cy.request({
+            url: SERVICE_DIRECTOR_ADDRESS_PATH,
+            failOnStatusCode: false,
+          }).then((response) => {
+            expect(response.status).to.eq(404)
+          })
         })
       })
-    })
 
-    describe('where the service is not switching PSP', () => {
-      beforeEach(() => {
-        cy.task('clearStubs')
-        const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
-          type: LIVE_ACCOUNT_TYPE,
+      describe('where the service is not switching PSP', () => {
+        beforeEach(() => {
+          cy.task('clearStubs')
+          const adyenGatewayAccount = GatewayAccountFixture.forAdyen({
+            type: LIVE_ACCOUNT_TYPE,
+          })
+
+          const serviceFixture = new ServiceFixture({
+            externalId: SERVICE_EXTERNAL_ID,
+            gatewayAccountIds: [`${adyenGatewayAccount.id}`],
+            currentGoLiveStage: 'LIVE',
+          })
+          const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
+
+          cy.task('setupStubs', [
+            getUser(USER_EXTERNAL_ID).success(userFixture),
+            GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
+              adyenGatewayAccount
+            ),
+          ])
         })
 
-        const serviceFixture = new ServiceFixture({
-          externalId: SERVICE_EXTERNAL_ID,
-          gatewayAccountIds: [`${adyenGatewayAccount.id}`],
-          currentGoLiveStage: 'LIVE',
-        })
-        const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
-
-        cy.task('setupStubs', [
-          getUser(USER_EXTERNAL_ID).success(userFixture),
-          GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
-            adyenGatewayAccount
-          ),
-        ])
-      })
-
-      it('should return a 404 when attempting to view bank details', () => {
-        cy.request({
-          url: SERVICE_DIRECTOR_ADDRESS_PATH,
-          failOnStatusCode: false,
-        }).then((response) => {
-          expect(response.status).to.eq(404)
+        it('should return a 404 when attempting to view address page', () => {
+          cy.request({
+            url: SERVICE_DIRECTOR_ADDRESS_PATH,
+            failOnStatusCode: false,
+          }).then((response) => {
+            expect(response.status).to.eq(404)
+          })
         })
       })
     })

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
@@ -48,62 +48,82 @@ const setStubs = (additionalStubs = []) => {
   ])
 }
 
+const fromReviewQueryString = '?fromReview=true'
+
 describe(`Service director - check your answers`, () => {
   beforeEach(() => {
     cy.setEncryptedCookies(USER_EXTERNAL_ID)
   })
 
-  it('accessibility check', () => {
-    setStubs()
-
-    cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
-    cy.a11yCheck()
-  })
-
-  it('should display correct page title and headings', () => {
-    setStubs()
-
-    cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
-
-    checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
-    cy.get('h1').should('contain.text', `Check your answers`)
-  })
-
   describe('for a service that is migrating to adyen', () => {
-    it('should display a back link to service director details', () => {
-      setStubs()
+    describe('when navigating to the page directly', () => {
+      beforeEach(() => {
+        setStubs()
+      })
 
-      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+      it('should redirect to the migration tasks page', () => {
+        setStubs()
 
-      cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_ADDRESS_PATH)
+        cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+
+        cy.location('pathname').should('eq', TASK_LIST_PATH)
+      })
     })
 
-    it('should redirect to personal details page when change link is clicked in details card', () => {
-      setStubs()
+    describe('when navigating from the address page with fields populated', () => {
+      beforeEach(() => {
+        setStubs()
+        cy.visit(SERVICE_DIRECTOR_DETAILS_PATH)
+        cy.get('#first-name').type('John')
+        cy.get('#last-name').type('McClane')
 
-      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+        cy.get('#dob-day').type('25')
+        cy.get('#dob-month').type('12')
+        cy.get('#dob-year').type('1960')
 
-      cy.get(`[data-cy='edit-director-details']`).click()
-      cy.location('pathname').should('eq', SERVICE_DIRECTOR_DETAILS_PATH)
-    })
+        cy.get('#email').type('yippeekiyay@example.gov.uk')
 
-    it('should redirect to address page when change link is clicked in address card', () => {
-      setStubs()
+        cy.get('#service-director-details-submit').click()
 
-      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+        cy.get('#address-line1').type('7 Green Lane')
+        cy.get('#address-line2').type('Greenfield')
+        cy.get('#address-city').type('Greencity')
+        cy.get('#address-postcode').type('GR3 3NY')
 
-      cy.get(`[data-cy='edit-director-address']`).click()
-      cy.location('pathname').should('eq', SERVICE_DIRECTOR_ADDRESS_PATH)
-    })
+        cy.get('#service-director-address-submit').click()
+      })
 
-    it('should redirect to the task list page when continue is pressed', () => {
-      setStubs()
+      it('accessibility check', () => {
+        setStubs()
+        cy.a11yCheck()
+      })
 
-      cy.visit(SERVICE_DIRECTOR_ANSWERS_PATH)
+      it('should display correct page content', () => {
+        setStubs()
 
-      cy.get('#service-director-confirm').click()
+        checkServiceNavigation('Switch provider to Adyen now', TASK_LIST_PATH)
+        cy.get('h1').should('contain.text', `Check your answers`)
+        cy.get('.govuk-back-link').should('have.attr', 'href', SERVICE_DIRECTOR_ADDRESS_PATH + fromReviewQueryString)
 
-      cy.location('pathname').should('eq', TASK_LIST_PATH)
+        cy.get(`[data-cy='edit-director-details']`).should(
+          'have.attr',
+          'href',
+          SERVICE_DIRECTOR_DETAILS_PATH + fromReviewQueryString
+        )
+        cy.get(`[data-cy='edit-director-address']`).should(
+          'have.attr',
+          'href',
+          SERVICE_DIRECTOR_ADDRESS_PATH + fromReviewQueryString
+        )
+      })
+
+      it('should redirect to the migration task page when continue is pressed', () => {
+        setStubs()
+
+        cy.get('#service-director-confirm').click()
+
+        cy.location('pathname').should('eq', TASK_LIST_PATH)
+      })
     })
   })
 
@@ -142,7 +162,7 @@ describe(`Service director - check your answers`, () => {
         ])
       })
 
-      it('should return a 404 when attempting to view service director details', () => {
+      it('should return a 404 when attempting to view check your answers page', () => {
         cy.request({
           url: SERVICE_DIRECTOR_ANSWERS_PATH,
           failOnStatusCode: false,
@@ -174,7 +194,7 @@ describe(`Service director - check your answers`, () => {
         ])
       })
 
-      it('should return a 404 when attempting to view bank details', () => {
+      it('should return a 404 when attempting to view check your answers page', () => {
         cy.request({
           url: SERVICE_DIRECTOR_ANSWERS_PATH,
           failOnStatusCode: false,


### PR DESCRIPTION
## What

[PP-15751](https://payments-platform.atlassian.net/browse/PP-15751)

This PR completes the work on PP-15751 by adding persistence to answers entered throughout the flow so that they appear on the check your answers page. Also added more complicated back button logic, so that if the user clicks change on the check your answers page to return to the address/details page, pressing back would take them back to the check your answers page, not the previous page in the flow. 

- Added session data and passed through controllers.
- Added back button logic through params and passed through controllers.
- Updated unit tests. 
- Updated check-your-answers.njk to display session data.
- Updated cypress tests

[PP-15751]: https://payments-platform.atlassian.net/browse/PP-15751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ