### PR TITLE
PP-15877 Use data from adyen setup in connector to determine task status shown in selfservice

### DIFF
--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
@@ -21,24 +21,24 @@ const accountSetup = new AdyenAccountSetup({
   credential_external_id: 'something',
   tasks: {
     bank_details: {
-      status: 'NOT_STARTED'
+      status: 'NOT_STARTED',
     },
     director: {
-      status: 'NOT_STARTED'
+      status: 'NOT_STARTED',
     },
     responsible_person: {
-      status: 'COMPLETED'
+      status: 'COMPLETED',
     },
     legal_terms: {
-      status: 'COMPLETED'
+      status: 'COMPLETED',
     },
     reason_for_taking_payments: {
-      status: 'COMPLETED'
+      status: 'COMPLETED',
     },
     organisation_details: {
-      status: 'COMPLETED'
-    }
-  }
+      status: 'COMPLETED',
+    },
+  },
 })
 
 const mockAdyenSetupService = {
@@ -57,7 +57,7 @@ const { req, res, call } = new ControllerTestBuilder(
   .withUser(UserFixture.asServiceAdmin([serviceFixture]).toUser())
   .withStubs({
     '@utils/response': { response: mockResponse },
-    '@services/adyen-setup.service': mockAdyenSetupService
+    '@services/adyen-setup.service': mockAdyenSetupService,
   })
   .build()
 

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.test.ts
@@ -7,6 +7,7 @@ import sinon from 'sinon'
 import { AdyenTasks } from '@models/task-workflows/AdyenTasks.class'
 import { AdyenTaskIdentifier } from '@models/task-workflows/task-identifiers/adyen-task-identifiers'
 import TaskStatus from '@models/constants/task-status'
+import { AdyenAccountSetup } from '@models/gateway-account/AdyenAccountSetup.class'
 
 const SERVICE_EXTERNAL_ID = 'service123abc'
 const serviceFixture = new ServiceFixture({
@@ -14,6 +15,35 @@ const serviceFixture = new ServiceFixture({
 })
 
 const mockResponse = sinon.stub()
+
+const accountSetup = new AdyenAccountSetup({
+  service_id: SERVICE_EXTERNAL_ID,
+  credential_external_id: 'something',
+  tasks: {
+    bank_details: {
+      status: 'NOT_STARTED'
+    },
+    director: {
+      status: 'NOT_STARTED'
+    },
+    responsible_person: {
+      status: 'COMPLETED'
+    },
+    legal_terms: {
+      status: 'COMPLETED'
+    },
+    reason_for_taking_payments: {
+      status: 'COMPLETED'
+    },
+    organisation_details: {
+      status: 'COMPLETED'
+    }
+  }
+})
+
+const mockAdyenSetupService = {
+  getConnectorAdyenAccountSetup: sinon.stub().resolves(accountSetup),
+}
 
 const { req, res, call } = new ControllerTestBuilder(
   '@controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller'
@@ -27,6 +57,7 @@ const { req, res, call } = new ControllerTestBuilder(
   .withUser(UserFixture.asServiceAdmin([serviceFixture]).toUser())
   .withStubs({
     '@utils/response': { response: mockResponse },
+    '@services/adyen-setup.service': mockAdyenSetupService
   })
   .build()
 
@@ -58,21 +89,21 @@ describe('Switch to Adyen controller tests', () => {
     context.adyenTasks.completeOrganisationDetailsTasks.should.have.length(4)
 
     context.adyenTasks.confirmOrganisationTasks[0].id.should.eq(AdyenTaskIdentifier.ORG_DETAILS)
-    context.adyenTasks.confirmOrganisationTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
+    context.adyenTasks.confirmOrganisationTasks[0].status.should.eq(TaskStatus.COMPLETED)
 
     context.adyenTasks.acceptLegalTermsTasks[0].id.should.eq(AdyenTaskIdentifier.LEGAL_TERMS)
-    context.adyenTasks.acceptLegalTermsTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
+    context.adyenTasks.acceptLegalTermsTasks[0].status.should.eq(TaskStatus.COMPLETED)
 
     context.adyenTasks.completeOrganisationDetailsTasks[0].id.should.eq(AdyenTaskIdentifier.BANK_DETAILS)
     context.adyenTasks.completeOrganisationDetailsTasks[0].status.should.eq(TaskStatus.NOT_STARTED)
 
     context.adyenTasks.completeOrganisationDetailsTasks[1].id.should.eq(AdyenTaskIdentifier.RESPONSIBLE_PERSON)
-    context.adyenTasks.completeOrganisationDetailsTasks[1].status.should.eq(TaskStatus.NOT_STARTED)
+    context.adyenTasks.completeOrganisationDetailsTasks[1].status.should.eq(TaskStatus.COMPLETED)
 
     context.adyenTasks.completeOrganisationDetailsTasks[2].id.should.eq(AdyenTaskIdentifier.SERVICE_DIRECTOR)
     context.adyenTasks.completeOrganisationDetailsTasks[2].status.should.eq(TaskStatus.NOT_STARTED)
 
     context.adyenTasks.completeOrganisationDetailsTasks[3].id.should.eq(AdyenTaskIdentifier.REASON_FOR_TAKING_PAYMENTS)
-    context.adyenTasks.completeOrganisationDetailsTasks[3].status.should.eq(TaskStatus.NOT_STARTED)
+    context.adyenTasks.completeOrganisationDetailsTasks[3].status.should.eq(TaskStatus.COMPLETED)
   })
 })

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
@@ -2,9 +2,12 @@ import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { response } from '@utils/response'
 import { AdyenTasks } from '@models/task-workflows/AdyenTasks.class'
 import { ResponsiblePersonSession } from '../../adyen-details/responsible-person/constants'
+import { getConnectorAdyenAccountSetup } from '@services/adyen-setup.service'
 
-function get(req: ServiceRequest, res: ServiceResponse) {
-  const adyenTasks = AdyenTasks.forProviderSwitching(req.service, req.account)
+async function get(req: ServiceRequest, res: ServiceResponse) {
+
+  const accountSetup = await getConnectorAdyenAccountSetup(req.service.externalId, req.account.type, req.account.getSwitchingCredential().externalId)
+  const adyenTasks = AdyenTasks.forProviderSwitching(req.service, req.account, accountSetup)
   ResponsiblePersonSession.clear(req)
 
   return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/index.njk', {

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/switch-to-adyen.controller.ts
@@ -5,8 +5,11 @@ import { ResponsiblePersonSession } from '../../adyen-details/responsible-person
 import { getConnectorAdyenAccountSetup } from '@services/adyen-setup.service'
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
-
-  const accountSetup = await getConnectorAdyenAccountSetup(req.service.externalId, req.account.type, req.account.getSwitchingCredential().externalId)
+  const accountSetup = await getConnectorAdyenAccountSetup(
+    req.service.externalId,
+    req.account.type,
+    req.account.getSwitchingCredential().externalId
+  )
   const adyenTasks = AdyenTasks.forProviderSwitching(req.service, req.account, accountSetup)
   ResponsiblePersonSession.clear(req)
 

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -12,7 +12,11 @@ class AdyenTask extends Task {
     super(linkText, id, href)
   }
 
-  static organisationDetailsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
+  static organisationDetailsTask(
+    service: Service,
+    gatewayAccount: GatewayAccount,
+    adyenAccountSetup: AdyenAccountSetup
+  ) {
     return new AdyenTask(
       'Organisation details',
       AdyenTaskIdentifier.ORG_DETAILS,
@@ -76,7 +80,11 @@ class AdyenTask extends Task {
     ).setStatus(adyenAccountSetup.tasks.director.status)
   }
 
-  static reasonForTakingPaymentsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
+  static reasonForTakingPaymentsTask(
+    service: Service,
+    gatewayAccount: GatewayAccount,
+    adyenAccountSetup: AdyenAccountSetup
+  ) {
     const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
 
     return new AdyenTask(

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -1,6 +1,5 @@
 import { Task, Tasks } from '@models/task-workflows/Tasks.class'
 import { AdyenTaskIdentifier } from '@models/task-workflows/task-identifiers/adyen-task-identifiers'
-import TaskStatus from '@models/constants/task-status'
 import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/format-service-and-account-paths-for'
 import paths from '@root/paths'
 import Service from '@models/service/Service.class'

--- a/src/models/task-workflows/AdyenTasks.class.ts
+++ b/src/models/task-workflows/AdyenTasks.class.ts
@@ -5,21 +5,22 @@ import formatServiceAndAccountPathsFor from '@utils/simplified-account/format/fo
 import paths from '@root/paths'
 import Service from '@models/service/Service.class'
 import GatewayAccount from '@models/gateway-account/GatewayAccount.class'
+import { AdyenAccountSetup } from '@models/gateway-account/AdyenAccountSetup.class'
 
 class AdyenTask extends Task {
   constructor(linkText: string, id: AdyenTaskIdentifier, href: string) {
     super(linkText, id, href)
   }
 
-  static organisationDetailsTask(service: Service, gatewayAccount: GatewayAccount) {
+  static organisationDetailsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     return new AdyenTask(
       'Organisation details',
       AdyenTaskIdentifier.ORG_DETAILS,
       formatServiceAndAccountPathsFor(paths.simplifiedAccount.settings.index, service.externalId, gatewayAccount.type)
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.organisationDetails.status)
   }
 
-  static acceptLegalTermsTask(service: Service, gatewayAccount: GatewayAccount) {
+  static acceptLegalTermsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     return new AdyenTask(
       'Read and accept Adyen’s legal terms',
       AdyenTaskIdentifier.LEGAL_TERMS,
@@ -29,9 +30,9 @@ class AdyenTask extends Task {
         gatewayAccount.type,
         gatewayAccount.getSwitchingCredential().externalId
       )
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.legalTerms.status)
   }
-  static bankDetailsTask(service: Service, gatewayAccount: GatewayAccount) {
+  static bankDetailsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
 
     return new AdyenTask(
@@ -43,10 +44,10 @@ class AdyenTask extends Task {
         gatewayAccount.type,
         switchingCredentialId
       )
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.bankDetails.status)
   }
 
-  static responsiblePersonTask(service: Service, gatewayAccount: GatewayAccount) {
+  static responsiblePersonTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
 
     return new AdyenTask(
@@ -58,10 +59,10 @@ class AdyenTask extends Task {
         gatewayAccount.type,
         switchingCredentialId
       )
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.responsiblePerson.status)
   }
 
-  static serviceDirectorTask(service: Service, gatewayAccount: GatewayAccount) {
+  static serviceDirectorTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
     return new AdyenTask(
       'Service director',
@@ -72,10 +73,10 @@ class AdyenTask extends Task {
         gatewayAccount.type,
         switchingCredentialId
       )
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.director.status)
   }
 
-  static reasonForTakingPaymentsTask(service: Service, gatewayAccount: GatewayAccount) {
+  static reasonForTakingPaymentsTask(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
     const switchingCredentialId = gatewayAccount.getSwitchingCredential().externalId
 
     return new AdyenTask(
@@ -87,7 +88,7 @@ class AdyenTask extends Task {
         gatewayAccount.type,
         switchingCredentialId
       )
-    ).setStatus(TaskStatus.NOT_STARTED)
+    ).setStatus(adyenAccountSetup.tasks.reasonForTakingPayments.status)
   }
 }
 
@@ -107,14 +108,14 @@ export class AdyenTasks extends Tasks<AdyenTask> {
     this.completeOrganisationDetailsTasks = completeOrganisationDetailsTasks
   }
 
-  static forProviderSwitching(service: Service, gatewayAccount: GatewayAccount) {
-    const confirmOrganisationTasks = [AdyenTask.organisationDetailsTask(service, gatewayAccount)]
-    const acceptLegalTermsTasks = [AdyenTask.acceptLegalTermsTask(service, gatewayAccount)]
+  static forProviderSwitching(service: Service, gatewayAccount: GatewayAccount, adyenAccountSetup: AdyenAccountSetup) {
+    const confirmOrganisationTasks = [AdyenTask.organisationDetailsTask(service, gatewayAccount, adyenAccountSetup)]
+    const acceptLegalTermsTasks = [AdyenTask.acceptLegalTermsTask(service, gatewayAccount, adyenAccountSetup)]
     const completeOrganisationDetailsTasks = [
-      AdyenTask.bankDetailsTask(service, gatewayAccount),
-      AdyenTask.responsiblePersonTask(service, gatewayAccount),
-      AdyenTask.serviceDirectorTask(service, gatewayAccount),
-      AdyenTask.reasonForTakingPaymentsTask(service, gatewayAccount),
+      AdyenTask.bankDetailsTask(service, gatewayAccount, adyenAccountSetup),
+      AdyenTask.responsiblePersonTask(service, gatewayAccount, adyenAccountSetup),
+      AdyenTask.serviceDirectorTask(service, gatewayAccount, adyenAccountSetup),
+      AdyenTask.reasonForTakingPaymentsTask(service, gatewayAccount, adyenAccountSetup),
     ]
     return new AdyenTasks(confirmOrganisationTasks, acceptLegalTermsTasks, completeOrganisationDetailsTasks)
   }

--- a/src/services/adyen-setup.service.ts
+++ b/src/services/adyen-setup.service.ts
@@ -1,3 +1,19 @@
+import ConnectorClient from '@services/clients/pay/ConnectorClient.class'
+
+const connectorClient = new ConnectorClient()
+
+const getConnectorAdyenAccountSetup = async (serviceExternalId: string, accountType: string, credentialExternalId: string) => {
+  return connectorClient.gatewayAccounts.adyenSetup.get(
+    serviceExternalId,
+    accountType,
+    credentialExternalId
+  )
+}
+
 export async function markTaskAsComplete() {
   // call client method
+}
+
+export {
+  getConnectorAdyenAccountSetup
 }

--- a/src/services/adyen-setup.service.ts
+++ b/src/services/adyen-setup.service.ts
@@ -2,18 +2,16 @@ import ConnectorClient from '@services/clients/pay/ConnectorClient.class'
 
 const connectorClient = new ConnectorClient()
 
-const getConnectorAdyenAccountSetup = async (serviceExternalId: string, accountType: string, credentialExternalId: string) => {
-  return connectorClient.gatewayAccounts.adyenSetup.get(
-    serviceExternalId,
-    accountType,
-    credentialExternalId
-  )
+const getConnectorAdyenAccountSetup = async (
+  serviceExternalId: string,
+  accountType: string,
+  credentialExternalId: string
+) => {
+  return connectorClient.gatewayAccounts.adyenSetup.get(serviceExternalId, accountType, credentialExternalId)
 }
 
 export async function markTaskAsComplete() {
   // call client method
 }
 
-export {
-  getConnectorAdyenAccountSetup
-}
+export { getConnectorAdyenAccountSetup }

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/address.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/address.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupFixture } from '@test/fixtures/gateway-account/adyen-account-setup.fixture'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -38,12 +39,23 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const adyenAccountSetup = AdyenAccountSetupFixture.Completed({
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  credentialExternalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+})
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      adyenAccountSetup.toAdyenAccountSetupData().tasks
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/check-your-answers.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/check-your-answers.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupFixture } from '@test/fixtures/gateway-account/adyen-account-setup.fixture'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -39,12 +40,23 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const adyenAccountSetup = AdyenAccountSetupFixture.Completed({
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  credentialExternalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+})
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      adyenAccountSetup.toAdyenAccountSetupData().tasks
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/contact-details.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/responsible-person/contact-details.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupFixture } from '@test/fixtures/gateway-account/adyen-account-setup.fixture'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -39,12 +40,23 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const adyenAccountSetup = AdyenAccountSetupFixture.Completed({
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  credentialExternalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+})
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      adyenAccountSetup.toAdyenAccountSetupData().tasks
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/address.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupFixture } from '@test/fixtures/gateway-account/adyen-account-setup.fixture'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -38,12 +39,23 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const adyenAccountSetup = AdyenAccountSetupFixture.Completed({
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  credentialExternalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+})
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      adyenAccountSetup.toAdyenAccountSetupData().tasks
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/adyen-details/service-director/check-your-answers.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupFixture } from '@test/fixtures/gateway-account/adyen-account-setup.fixture'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -38,12 +39,23 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const adyenAccountSetup = AdyenAccountSetupFixture.Completed({
+  serviceExternalId: SERVICE_EXTERNAL_ID,
+  credentialExternalId: ADYEN_CREDENTIAL_EXTERNAL_ID,
+})
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      adyenAccountSetup.toAdyenAccountSetupData().tasks
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -5,7 +5,10 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
-import { AdyenAccountSetupTaskData, AdyenAccountSetupTaskNameData } from '@models/gateway-account/dto/AdyenAccountSetup.dto'
+import {
+  AdyenAccountSetupTaskData,
+  AdyenAccountSetupTaskNameData,
+} from '@models/gateway-account/dto/AdyenAccountSetup.dto'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -36,23 +39,23 @@ const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: U
 
 const tasksWithStatus: Record<AdyenAccountSetupTaskNameData, AdyenAccountSetupTaskData> = {
   bank_details: {
-    status: 'NOT_STARTED'
+    status: 'NOT_STARTED',
   },
   director: {
-    status: 'NOT_STARTED'
+    status: 'NOT_STARTED',
   },
   responsible_person: {
-    status: 'COMPLETED'
+    status: 'COMPLETED',
   },
   legal_terms: {
-    status: 'COMPLETED'
+    status: 'COMPLETED',
   },
   reason_for_taking_payments: {
-    status: 'COMPLETED'
+    status: 'COMPLETED',
   },
   organisation_details: {
-    status: 'COMPLETED'
-  }
+    status: 'COMPLETED',
+  },
 }
 
 const setStubs = (additionalStubs = []) => {
@@ -61,7 +64,12 @@ const setStubs = (additionalStubs = []) => {
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
-    GatewayAccountStubs.getAdyenSetpTasks(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE, ADYEN_CREDENTIAL_EXTERNAL_ID, tasksWithStatus).success(),
+    GatewayAccountStubs.getAdyenSetpTasks(
+      SERVICE_EXTERNAL_ID,
+      LIVE_ACCOUNT_TYPE,
+      ADYEN_CREDENTIAL_EXTERNAL_ID,
+      tasksWithStatus
+    ).success(),
     ...additionalStubs,
   ])
 }

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -5,6 +5,7 @@ import { PaymentProvider } from '@models/constants/payment-provider'
 import { getUser } from '@test/cypress/stubs/simplified-account/user-stubs'
 import * as GatewayAccountStubs from '@test/cypress/stubs/simplified-account/gateway-account-stubs'
 import { checkServiceNavigation } from '@test/cypress/integration/simplified-account/common/assertions'
+import { AdyenAccountSetupTaskData, AdyenAccountSetupTaskNameData } from '@models/gateway-account/dto/AdyenAccountSetup.dto'
 
 const USER_EXTERNAL_ID = 'user-123-abc'
 const SERVICE_EXTERNAL_ID = 'service456def'
@@ -33,12 +34,34 @@ const serviceFixture = new ServiceFixture({
 })
 const userFixture = UserFixture.asServiceAdmin([serviceFixture], { externalId: USER_EXTERNAL_ID })
 
+const tasksWithStatus: Record<AdyenAccountSetupTaskNameData, AdyenAccountSetupTaskData> = {
+  bank_details: {
+    status: 'NOT_STARTED'
+  },
+  director: {
+    status: 'NOT_STARTED'
+  },
+  responsible_person: {
+    status: 'COMPLETED'
+  },
+  legal_terms: {
+    status: 'COMPLETED'
+  },
+  reason_for_taking_payments: {
+    status: 'COMPLETED'
+  },
+  organisation_details: {
+    status: 'COMPLETED'
+  }
+}
+
 const setStubs = (additionalStubs = []) => {
   cy.task('setupStubs', [
     getUser(USER_EXTERNAL_ID).success(userFixture),
     GatewayAccountStubs.getByServiceExternalIdAndAccountType(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE).success(
       gatewayAccountFixture
     ),
+    GatewayAccountStubs.getAdyenSetpTasks(SERVICE_EXTERNAL_ID, LIVE_ACCOUNT_TYPE, ADYEN_CREDENTIAL_EXTERNAL_ID, tasksWithStatus).success(),
     ...additionalStubs,
   ])
 }
@@ -72,7 +95,7 @@ describe('switch to adyen task list', () => {
     cy.get('h1').should('contain.text', 'Switch your payment provider to Adyen')
   })
 
-  describe('for a service that has completed no migration tasks', () => {
+  describe('for a service that has completed some migration tasks', () => {
     it('should show the task list with all tasks in the correct state', () => {
       setStubs()
 
@@ -90,7 +113,7 @@ describe('switch to adyen task list', () => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Organisation details')
                 .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
-              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+              cy.get('.govuk-task-list__status').should('contain.text', 'Completed')
             })
         })
 
@@ -110,7 +133,7 @@ describe('switch to adyen task list', () => {
                   'href',
                   `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/legal-terms`
                 )
-              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+              cy.get('.govuk-task-list__status').should('contain.text', 'Completed')
             })
         })
 
@@ -143,7 +166,7 @@ describe('switch to adyen task list', () => {
                   'href',
                   `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/responsible-person/details`
                 )
-              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+              cy.get('.govuk-task-list__status').should('contain.text', 'Completed')
             })
 
           cy.get('.govuk-task-list__item')
@@ -169,7 +192,7 @@ describe('switch to adyen task list', () => {
                   'href',
                   `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/reason-for-taking-payments`
                 )
-              cy.get('.govuk-task-list__status').should('contain.text', 'Not yet started')
+              cy.get('.govuk-task-list__status').should('contain.text', 'Completed')
             })
         })
     })

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/switch-to-adyen.cy.ts
@@ -120,7 +120,11 @@ describe('switch to adyen task list', () => {
             .within(() => {
               cy.get('.govuk-task-list__link')
                 .should('contain.text', 'Organisation details')
-                .should('have.attr', 'href', `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings`)
+                .should(
+                  'have.attr',
+                  'href',
+                  `/service/${SERVICE_EXTERNAL_ID}/account/${LIVE_ACCOUNT_TYPE}/settings/adyen-details/${ADYEN_CREDENTIAL_EXTERNAL_ID}/organisation-details/details`
+                )
               cy.get('.govuk-task-list__status').should('contain.text', 'Completed')
             })
         })

--- a/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
+++ b/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
@@ -1,5 +1,6 @@
 import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
 import { stubBuilder } from '@test/cypress/stubs/stub-builder'
+import { AdyenAccountSetupData, AdyenAccountSetupTaskData, AdyenAccountSetupTaskNameData } from '@models/gateway-account/dto/AdyenAccountSetup.dto'
 
 export function searchByServiceExternalIds(serviceExternalIds: string[]) {
   const path = `/v1/api/accounts`
@@ -25,6 +26,23 @@ export function getByServiceExternalIdAndAccountType(serviceExternalId: string, 
     success: function (gatewayAccount: GatewayAccountFixture) {
       return stubBuilder('GET', path, 200, {
         response: gatewayAccount.toGatewayAccountData(),
+      })
+    },
+  }
+}
+
+export function getAdyenSetpTasks(serviceExternalId: string, accountType: string, credentialExternalId: string, tasksWithStatus: Record<AdyenAccountSetupTaskNameData, AdyenAccountSetupTaskData>) {
+  const path = `/v1/api/service/${serviceExternalId}/account/${accountType}/adyen-setup/${credentialExternalId}`
+  const data: AdyenAccountSetupData = {
+    service_id: serviceExternalId,
+    credential_external_id: credentialExternalId,
+    tasks: tasksWithStatus
+  }
+
+  return {
+    success: function () {
+      return stubBuilder('GET', path, 200, {
+        response: data,
       })
     },
   }

--- a/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
+++ b/test/cypress/stubs/simplified-account/gateway-account-stubs.ts
@@ -1,6 +1,10 @@
 import { GatewayAccountFixture } from '@test/fixtures/gateway-account/gateway-account.fixture'
 import { stubBuilder } from '@test/cypress/stubs/stub-builder'
-import { AdyenAccountSetupData, AdyenAccountSetupTaskData, AdyenAccountSetupTaskNameData } from '@models/gateway-account/dto/AdyenAccountSetup.dto'
+import {
+  AdyenAccountSetupData,
+  AdyenAccountSetupTaskData,
+  AdyenAccountSetupTaskNameData,
+} from '@models/gateway-account/dto/AdyenAccountSetup.dto'
 
 export function searchByServiceExternalIds(serviceExternalIds: string[]) {
   const path = `/v1/api/accounts`
@@ -31,12 +35,17 @@ export function getByServiceExternalIdAndAccountType(serviceExternalId: string, 
   }
 }
 
-export function getAdyenSetpTasks(serviceExternalId: string, accountType: string, credentialExternalId: string, tasksWithStatus: Record<AdyenAccountSetupTaskNameData, AdyenAccountSetupTaskData>) {
+export function getAdyenSetpTasks(
+  serviceExternalId: string,
+  accountType: string,
+  credentialExternalId: string,
+  tasksWithStatus: Record<AdyenAccountSetupTaskNameData, AdyenAccountSetupTaskData>
+) {
   const path = `/v1/api/service/${serviceExternalId}/account/${accountType}/adyen-setup/${credentialExternalId}`
   const data: AdyenAccountSetupData = {
     service_id: serviceExternalId,
     credential_external_id: credentialExternalId,
-    tasks: tasksWithStatus
+    tasks: tasksWithStatus,
   }
 
   return {


### PR DESCRIPTION
## What

PP-15877

- Update switch to Adyen controller to call Adyen setup service
- Add connector call in Adyen setup service to retrieve task status
- Update Adyen tasks class to use this status, where previously it was hardcoded
- Display the dynamic status in the switch to Adyen view

### How

- navigate to Settings -> Payment provider -> Switch provider to Adyen now, from a service in the correct state for switching
  - this can be setup by running `pay local service <email>` from the latest version on [Pay CLI](https://github.com/govuk-pay/pay-cli), where `email` is the associated with a user you have created locally, and login to self-service with
- On the `switch-to-adyen` page, all tasks (eg. `Service director`) should have a status of `Not yet started`
- To update a task, make a PATCH request to `/v1/api/service/:serviceId/account/live/adyen-setup/:credentialExternalId` of a locally running connector istance with a body of: 
```
[
  {
    "op": "replace",
    "path": "responsible_person",
    "value": "COMPLETED"
  }
]
```
- The task status should update when you refresh your browser


### Screenshots (views have been added/changed)

[
<img width="669" height="788" alt="Screenshot 2026-09-11 at 15 14 48" src="https://github.com/user-attachments/assets/21dd636d-cf3e-4be3-80a9-b1508af6bc73" />
](url)
