### PR TITLE
PP-14739 Fix HTTP 409 response when inviting user to a service

### DIFF
--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.js
@@ -6,44 +6,49 @@ const { body, validationResult } = require('express-validator')
 const formatValidationErrors = require('@utils/simplified-account/format/format-validation-errors')
 const userService = require('@services/user.service')
 
-async function get (req, res) {
+async function get(req, res) {
   const serviceId = req.service.externalId
   const accountType = req.account.type
-  response(req, res, 'simplified-account/settings/team-members/invite',
-    {
-      availableRoles: getAvailableRolesForService(req.service.agentInitiatedMotoEnabled ?? false),
-      backLink: formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, serviceId, accountType)
-    })
+  response(req, res, 'simplified-account/settings/team-members/invite', {
+    availableRoles: getAvailableRolesForService(req.service.agentInitiatedMotoEnabled ?? false),
+    backLink: formatSimplifiedAccountPathsFor(
+      paths.simplifiedAccount.settings.teamMembers.index,
+      serviceId,
+      accountType
+    ),
+  })
 }
 
-async function post (req, res, next) {
+async function post(req, res, next) {
   const externalServiceId = req.service.externalId
   const accountType = req.account.type
   const adminUserExternalId = req.user.externalId
   const invitedUserEmail = req.body.invitedUserEmail
   const invitedUserRole = req.body.invitedUserRole
-  const teamMembersIndexPath = formatSimplifiedAccountPathsFor(paths.simplifiedAccount.settings.teamMembers.index, externalServiceId, accountType)
+  const teamMembersIndexPath = formatSimplifiedAccountPathsFor(
+    paths.simplifiedAccount.settings.teamMembers.index,
+    externalServiceId,
+    accountType
+  )
 
   const responseWithErrors = (errors) => {
     return response(req, res, 'simplified-account/settings/team-members/invite', {
       errors: {
         summary: errors.errorSummary,
-        formErrors: errors.formErrors
+        formErrors: errors.formErrors,
       },
       invitedUserEmail,
       checkedRole: invitedUserRole,
       availableRoles: getAvailableRolesForService(req.service.agentInitiatedMotoEnabled ?? false),
-      backLink: teamMembersIndexPath
+      backLink: teamMembersIndexPath,
     })
   }
 
   const validations = [
-    body('invitedUserEmail')
-      .isEmail().withMessage('Enter a valid email address'),
-    body('invitedUserRole')
-      .not().isEmpty().withMessage('Select a permission level')
+    body('invitedUserEmail').isEmail().withMessage('Enter a valid email address'),
+    body('invitedUserRole').not().isEmpty().withMessage('Select a permission level'),
   ]
-  await Promise.all(validations.map(validation => validation.run(req)))
+  await Promise.all(validations.map((validation) => validation.run(req)))
   const validationErrors = validationResult(req)
   if (!validationErrors.isEmpty()) {
     const formattedValidationErrors = formatValidationErrors(validationErrors)
@@ -51,14 +56,25 @@ async function post (req, res, next) {
   }
 
   try {
-    await userService.createInviteToJoinService(invitedUserEmail, adminUserExternalId, externalServiceId, invitedUserRole)
-    req.flash('messages', { state: 'success', icon: '&check;', heading: `Team member invitation sent to ${req.body.invitedUserEmail}` })
+    await userService.createInviteToJoinService(
+      invitedUserEmail,
+      adminUserExternalId,
+      externalServiceId,
+      invitedUserRole
+    )
+    req.flash('messages', {
+      state: 'success',
+      icon: '&check;',
+      heading: `Team member invitation sent to ${req.body.invitedUserEmail}`,
+    })
     res.redirect(teamMembersIndexPath)
   } catch (err) {
-    if (err.errorCode === 412) {
+    if (err.errorCode === 412 || err.errorCode === 409) {
       const personAlreadyInvitedError = {
         errorSummary: [{ text: 'This person has already been invited', href: '#invited-user-email' }],
-        formErrors: { invitedUserEmail: `You cannot send an invitation to ${req.body.invitedUserEmail} because they have received one already, or may be an existing team member` }
+        formErrors: {
+          invitedUserEmail: `You cannot send an invitation to ${req.body.invitedUserEmail} because they have received one already, or may be an existing team member`,
+        },
       }
       return responseWithErrors(personAlreadyInvitedError)
     }
@@ -68,5 +84,5 @@ async function post (req, res, next) {
 
 module.exports = {
   get,
-  post
+  post,
 }

--- a/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
+++ b/src/controllers/simplified-account/settings/team-members/invite/invite.controller.test.js
@@ -9,26 +9,30 @@ const { RESTClientError } = require('@govuk-pay/pay-js-commons/lib/utils/axios-b
 const ACCOUNT_TYPE = 'test'
 const SERVICE_ID = 'service-id-123abc'
 
-const adminUser = new User(userFixtures.validUserResponse({
-  external_id: 'user-id-for-admin-user',
-  email: 'admin-user@users.gov.uk',
-  service_roles: {
-    service: {
-      service: { external_id: SERVICE_ID },
-      role: { name: 'admin' }
-    }
-  }
-}))
+const adminUser = new User(
+  userFixtures.validUserResponse({
+    external_id: 'user-id-for-admin-user',
+    email: 'admin-user@users.gov.uk',
+    service_roles: {
+      service: {
+        service: { external_id: SERVICE_ID },
+        role: { name: 'admin' },
+      },
+    },
+  })
+)
 
 const mockResponse = sinon.stub()
 const mockCreateInviteToJoinService = sinon.stub()
 
-const { req, res, nextRequest, call } = new ControllerTestBuilder('@controllers/simplified-account/settings/team-members/invite/invite.controller')
+const { req, res, nextRequest, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/team-members/invite/invite.controller'
+)
   .withServiceExternalId(SERVICE_ID)
   .withAccountType(ACCOUNT_TYPE)
   .withStubs({
     '@utils/response': { response: mockResponse },
-    '@services/user.service': { createInviteToJoinService: mockCreateInviteToJoinService }
+    '@services/user.service': { createInviteToJoinService: mockCreateInviteToJoinService },
   })
   .withUser(adminUser)
   .build()
@@ -51,7 +55,9 @@ describe('Controller: settings/team-members/invite', () => {
 
     it('should pass context data to the response method', () => {
       expect(mockResponse.args[0][3]).to.have.property('availableRoles').to.have.length(3)
-      expect(mockResponse.args[0][3]).to.have.property('backLink').to.equal('/service/service-id-123abc/account/test/settings/team-members')
+      expect(mockResponse.args[0][3])
+        .to.have.property('backLink')
+        .to.equal('/service/service-id-123abc/account/test/settings/team-members')
     })
   })
 })
@@ -60,44 +66,98 @@ describe('post', () => {
   describe('success', () => {
     beforeEach(async () => {
       nextRequest({
-        body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
+        body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' },
       })
       mockCreateInviteToJoinService.resolves()
       await call('post')
     })
 
     it('should call adminusers to send an invite', () => {
-      expect(mockCreateInviteToJoinService.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true
+      expect(
+        mockCreateInviteToJoinService.calledWith(
+          'user-to-invite@users.gov.uk',
+          adminUser.externalId,
+          SERVICE_ID,
+          'view-only'
+        )
+      ).to.be.true
     })
 
     it('should redirect to the team members index page', () => {
       expect(req.flash).to.have.been.calledWith('messages', {
         state: 'success',
         icon: '&check;',
-        heading: 'Team member invitation sent to user-to-invite@users.gov.uk'
+        heading: 'Team member invitation sent to user-to-invite@users.gov.uk',
       })
       expect(res.redirect.calledOnce).to.be.true
       expect(res.redirect.args[0][0]).to.include(paths.simplifiedAccount.settings.teamMembers.index)
     })
   })
 
-  describe('failure - user already in service', () => {
-    beforeEach(async () => {
-      nextRequest({
-        body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' }
+  describe('failure', () => {
+    describe('user already in service', () => {
+      beforeEach(async () => {
+        nextRequest({
+          body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' },
+        })
+        mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412))
+        await call('post')
       })
-      mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 412))
-      await call('post')
+
+      it('should respond with error message', () => {
+        expect(
+          mockCreateInviteToJoinService.calledWith(
+            'user-to-invite@users.gov.uk',
+            adminUser.externalId,
+            SERVICE_ID,
+            'view-only'
+          )
+        ).to.be.true
+        expect(mockResponse.calledOnce).to.be.true
+        expect(mockResponse.args[0][1]).to.deep.equal(res)
+        expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/team-members/invite')
+        expect(mockResponse.args[0][3])
+          .to.have.property('errors')
+          .to.deep.equal({
+            summary: [{ text: 'This person has already been invited', href: '#invited-user-email' }],
+            formErrors: {
+              invitedUserEmail:
+                'You cannot send an invitation to user-to-invite@users.gov.uk because they have received one already, or may be an existing team member',
+            },
+          })
+      })
     })
 
-    it('should respond with error message', () => {
-      expect(mockCreateInviteToJoinService.calledWith('user-to-invite@users.gov.uk', adminUser.externalId, SERVICE_ID, 'view-only')).to.be.true
-      expect(mockResponse.calledOnce).to.be.true
-      expect(mockResponse.args[0][1]).to.deep.equal(res)
-      expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/team-members/invite')
-      expect(mockResponse.args[0][3]).to.have.property('errors').to.deep.equal({
-        summary: [{ text: 'This person has already been invited', href: '#invited-user-email' }],
-        formErrors: { invitedUserEmail: 'You cannot send an invitation to user-to-invite@users.gov.uk because they have received one already, or may be an existing team member' }
+    describe('user already invited', () => {
+      beforeEach(async () => {
+        nextRequest({
+          body: { invitedUserEmail: 'user-to-invite@users.gov.uk', invitedUserRole: 'view-only' },
+        })
+        mockCreateInviteToJoinService.rejects(new RESTClientError(null, 'adminusers', 409))
+        await call('post')
+      })
+
+      it('should respond with error message', () => {
+        expect(
+          mockCreateInviteToJoinService.calledWith(
+            'user-to-invite@users.gov.uk',
+            adminUser.externalId,
+            SERVICE_ID,
+            'view-only'
+          )
+        ).to.be.true
+        expect(mockResponse.calledOnce).to.be.true
+        expect(mockResponse.args[0][1]).to.deep.equal(res)
+        expect(mockResponse.args[0][2]).to.equal('simplified-account/settings/team-members/invite')
+        expect(mockResponse.args[0][3])
+          .to.have.property('errors')
+          .to.deep.equal({
+            summary: [{ text: 'This person has already been invited', href: '#invited-user-email' }],
+            formErrors: {
+              invitedUserEmail:
+                'You cannot send an invitation to user-to-invite@users.gov.uk because they have received one already, or may be an existing team member',
+            },
+          })
       })
     })
   })


### PR DESCRIPTION
## What

PP-**14739**

_A brief description of the pull request_

- Handle `409 response` error in `invite.controller.js`
- Add unit tests for `409` response handling in `invite.controller.test.js`
- Format changed files with Prettier

### How
_Steps to test or reproduce_

- In Selfservice, invite any email address to a service

- As a **different user** on the **same service**, send an invite to the same email address

### Screenshots (views have been added/changed)
<img width="668" height="500" alt="Screenshot 2026-09-11 at 15 31 10" src="https://github.com/user-attachments/assets/9b4bf087-990c-4f85-91ac-ea6db39e591f" />